### PR TITLE
Bring autogrow-textarea to the future

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+bower_components

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,32 @@
+{
+  "name": "iron-autogrow-textarea",
+  "version": "0.8.0",
+  "authors": "The Polymer Authors",
+  "keywords": [
+    "web-components",
+    "web-component",
+    "polymer"
+  ],
+  "main": [
+    "iron-autogrow-textarea.html"
+  ],
+  "private": true,
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/PolymerElements/iron-autogrow-textarea.git"
+  },
+  "license": "MIT",
+  "homepage": "https://github.com/PolymerElements/iron-autogrow-textarea",
+  "ignore": [],
+  "dependencies": {
+    "polymer": "Polymer/polymer#v0.8.0-rc.7",
+    "iron-flex-layout": "PolymerElements/iron-flex-layout#v0.8.0"
+  },
+  "devDependencies": {
+    "iron-doc-viewer": "PolymerElements/iron-doc-viewer#^0.8.6",
+    "test-fixture": "PolymerElements/test-fixture#^0.8.0",
+    "web-component-tester": "Polymer/web-component-tester#^2.2.3",
+    "webcomponentsjs": "Polymer/webcomponentsjs#^0.6.0",
+    "paper-styles": "PolymerElements/paper-styles#^0.8.0"
+  }
+}

--- a/demo/index.html
+++ b/demo/index.html
@@ -1,0 +1,90 @@
+<!doctype html>
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+  <head>
+
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes">
+
+    <title>iron-autogrow-textarea demo</title>
+
+    <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+    <link rel="import" href="../iron-autogrow-textarea.html">
+
+    <link rel="stylesheet" href="../../paper-styles/demo.css">
+
+  </head>
+
+  <style>
+    textarea {
+      width: 400px;
+    }
+  </style>
+
+  <body>
+    <template is="x-autobind">
+      <section>
+        <div>Updating the value imperatively</div>
+        <iron-autogrow-textarea bind-value="{{bindValue}}" id="a1">
+          <textarea id="t1">asdfasdfasdfad</textarea>
+        </iron-autogrow-textarea>
+        <br><br>
+
+        <code>bind-value</code>: <span>[[bindValue]]</span>
+
+        <p on-click="setValue">
+          set <code>bind-value</code> to: <br>
+          <textarea></textarea>
+          <button value="bindValue">set</button>
+          <br><br>
+
+          set <code>textarea.value</code> to: <br>
+          <textarea></textarea>
+          <button value="value">set</button>
+        </p>
+      </section>
+    </template>
+
+    <section>
+      <div>Scrolls after 4 rows</div>
+      <iron-autogrow-textarea max-rows="4">
+        <textarea></textarea>
+      </iron-autogrow-textarea>
+    </section>
+
+    <section>
+      <div>Initial height of 4 rows</div>
+      <iron-autogrow-textarea rows="4">
+        <textarea></textarea>
+      </iron-autogrow-textarea>
+    </section>
+
+    <script>
+      var scope = document.querySelector('template[is=x-autobind]');
+
+      scope.setValue = function(event) {
+        if (!(event.target instanceof HTMLButtonElement)) {
+          return;
+        }
+        var inputValue = event.target.previousElementSibling.value;
+        if (event.target.value == "bindValue") {
+          document.querySelector('iron-autogrow-textarea').bindValue = inputValue;
+        } else {
+          document.querySelector('textarea').value = inputValue;
+          document.querySelector('iron-autogrow-textarea').update();
+        }
+
+      }
+    </script>
+    
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+  <head>
+
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+
+    <title>iron-autogrow-textarea</title>
+
+    <script src="../webcomponentsjs/webcomponents-lite.js"></script>
+
+    <link rel="import" href="../polymer/polymer.html">
+    <link rel="import" href="../iron-doc-viewer/iron-doc-viewer.html">
+
+  </head>
+  <body>
+
+    <iron-doc-viewer></iron-doc-viewer>
+
+  </body>
+</html>

--- a/iron-autogrow-textarea.html
+++ b/iron-autogrow-textarea.html
@@ -1,0 +1,207 @@
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../iron-flex-layout/iron-flex-layout.html">
+
+<!--
+`iron-autogrow-textarea` is an element containing a textarea that grows in height as more
+lines of input are entered. Unless an explicit height or the `maxRows` property is set, it will
+never scroll.
+
+Example:
+
+    <iron-autogrow-textarea id="a1">
+      <textarea id="t1"></textarea>
+    </iron-autogrow-textarea>
+
+Because the `textarea`'s `value` property is not observable, you should use
+this element's `bind-value` instead for imperative updates. Alternatively, if
+you do set the `textarea`'s `value` imperatively, you must also call `update`
+to notify this element the value has changed.
+
+    Example:
+        /* preferred, using the example HTML above*/
+        a1.bindValue = 'some\ntext';
+
+        /* alternatively, */
+        t1.value = 'some\ntext';
+        a1.update();
+-->
+
+<dom-module id="iron-autogrow-textarea">
+  <style>
+    :host {
+      display: inline-block;
+      position: relative;
+      width: 400px;
+    }
+
+    .mirror-text {
+      visibility: hidden;
+      word-wrap: break-word;
+    }
+
+    ::content textarea {
+      resize: none;
+      /* see comments in template */
+      width: 100%;
+      height: 100%;
+      font-size: inherit;
+      font-family: inherit;
+    }
+
+    ::content textarea:invalid {
+      box-shadow: none;
+    }
+
+    .textarea-container {
+      mixin(--layout-fit);
+    }
+
+  </style>
+  <template>
+    <!-- the mirror sizes the input/textarea so it grows with typing -->
+    <div id="mirror" class="mirror-text" aria-hidden="true">&nbsp;</div>
+
+    <!-- size the input/textarea with a div, because the textarea has intrinsic size in ff -->
+    <div class="textarea-container">
+      <content id="textarea" select="textarea"></content>
+    </div>
+  </template>
+
+<script>
+
+  Polymer({
+
+    is: 'iron-autogrow-textarea',
+
+    enableCustomStyleProperties: true,
+
+    properties: {
+
+      /**
+       * Use this property instead of `value` for two-way data binding.
+       */
+      bindValue: {
+        observer: '_bindValueChanged',
+        type: String
+      },
+
+      /**
+       * The initial number of rows.
+       *
+       * @attribute rows
+       * @type number
+       * @default 1
+       */
+      rows: {
+        type: Number,
+        value: 1,
+        observer: '_updateCached'
+      },
+
+      /**
+       * The maximum number of rows this element can grow to until it
+       * scrolls. 0 means no maximum.
+       *
+       * @attribute maxRows
+       * @type number
+       * @default 0
+       */
+      maxRows: {
+         type: Number,
+         value: 0,
+         observer: '_updateCached'
+      }
+    },
+
+    listeners: {
+      'input': '_onInput'
+    },
+
+    /**
+     * Returns the underlying textarea.
+     *
+     * @property textarea
+     * @type Element
+     */
+    get textarea() {
+      return Polymer.dom(this.$.textarea).getDistributedNodes()[0];
+    },
+
+    /**
+     * Sizes this element to fit the input value. This function is automatically called
+     * when the user types in new input, but you must call this function if the value
+     * is updated imperatively.
+     *
+     * @method update
+     */
+    update: function() {
+      this.$.mirror.innerHTML = this._valueForMirror();
+
+      var textarea = this.textarea;
+      // If the value of the textarea was updated imperatively, then we
+      // need to manually update bindValue as well.
+      if (textarea && this.bindValue != textarea.value) {
+        this.bindValue = textarea.value;
+      }
+    },
+
+    attached: function() {
+      this.bindValue = this.value;
+    },
+
+    _bindValueChanged: function() {
+      var textarea = this.textarea;
+      if (!textarea) {
+        return;
+      }
+
+      textarea.value = this.bindValue;
+      this.update();
+      // manually notify because we don't want to notify until after setting value
+      this.fire('bind-value-changed', {value: this.bindValue});
+    },
+
+    _onInput: function(event) {
+      this.bindValue = event.target.value;
+      this.update();
+    },
+
+    _constrain: function(tokens) {
+      var _tokens;
+      tokens = tokens || [''];
+      // Enforce the min and max heights for a multiline input to avoid measurement
+      if (this.maxRows > 0 && tokens.length > this.maxRows) {
+        _tokens = tokens.slice(0, this.maxRows);
+      } else {
+        _tokens = tokens.slice(0);
+      }
+      while (this.rows > 0 && _tokens.length < this.rows) {
+        _tokens.push('');
+      }
+      return _tokens.join('<br>') + '&nbsp;';
+    },
+
+    _valueForMirror: function() {
+      var input = this.textarea;
+      if (!input) {
+        return;
+      }
+      this.tokens = (input && input.value) ? input.value.replace(/&/gm, '&amp;').replace(/"/gm, '&quot;').replace(/'/gm, '&#39;').replace(/</gm, '&lt;').replace(/>/gm, '&gt;').split('\n') : [''];
+      return this._constrain(this.tokens);
+    },
+
+    _updateCached: function() {
+      this.$.mirror.innerHTML = this._constrain(this.tokens);
+    }
+  })
+</script>

--- a/test/basic.html
+++ b/test/basic.html
@@ -1,0 +1,84 @@
+<!doctype html>
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+  <head>
+
+    <title>iron-autogrow-textarea tests</title>
+
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+      <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes">
+
+    <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+
+    <script src="../../web-component-tester/browser.js"></script>
+    <script src="../../test-fixture/test-fixture-mocha.js"></script>
+
+    <link rel="import" href="../../test-fixture/test-fixture.html">
+    <link rel="import" href="../iron-autogrow-textarea.html">
+
+  </head>
+  <body>
+
+    <test-fixture id="basic">
+      <template>
+        <iron-autogrow-textarea>
+          <textarea></textarea>
+        </iron-autogrow-textarea>
+      </template>
+    </test-fixture>
+
+    <script>
+
+      suite('basic', function() {
+
+        test('setting bindValue sets textarea value', function() {
+          var autogrow = fixture('basic');
+          var textarea = autogrow.querySelector('textarea');
+
+          autogrow.bindValue = 'batman';
+          assert.equal(textarea.value, autogrow.bindValue, 'textarea value equals to bindValue');
+        });
+
+        test('textarea value sets bindValue after update', function() {
+          var autogrow = fixture('basic');
+          var textarea = autogrow.querySelector('textarea');
+
+          textarea.value = 'batman';
+          autogrow.update();
+
+          assert.equal(textarea.value, autogrow.bindValue, 'textarea value equals to bindValue');
+        });
+
+        test('adding rows grows the textarea', function() {
+          var autogrow = fixture('basic');
+          var initialHeight = autogrow.offsetHeight;
+
+          autogrow.bindValue = 'batman\nand\nrobin';
+          var finalHeight = autogrow.offsetHeight
+          assert.isTrue(finalHeight > initialHeight);
+        });
+
+        test('removing rows shrinks the textarea', function() {
+          var autogrow = fixture('basic');
+          autogrow.bindValue = 'batman\nand\nrobin';
+          var initialHeight = autogrow.offsetHeight;
+
+          autogrow.bindValue = 'batman';
+          var finalHeight = autogrow.offsetHeight
+          assert.isTrue(finalHeight < initialHeight);
+        });
+      });
+
+    </script>
+
+  </body>
+</html>

--- a/test/index.html
+++ b/test/index.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<!--
+@license
+Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+    <title>iron-autogrow-textarea tests</title>
+    <script src="../../web-component-tester/browser.js"></script>
+  </head>
+  <body>
+    <script>
+      WCT.loadSuites([
+        'basic.html',
+      ]);
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
:fire: 

For the record, this looked like this for most of today, and I wasn't even mad:
![textarea](https://cloud.githubusercontent.com/assets/1369170/7382562/6362e434-edc5-11e4-8ede-03be627fc10e.gif)
