### PR TITLE
Use layout classes instead of mixin

### DIFF
--- a/iron-autogrow-textarea.html
+++ b/iron-autogrow-textarea.html
@@ -9,7 +9,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 
 <link rel="import" href="../polymer/polymer.html">
-<link rel="import" href="../iron-flex-layout/iron-flex-layout.html">
+<link rel="import" href="../iron-flex-layout/classes/iron-flex-layout.html">
 
 <!--
 `iron-autogrow-textarea` is an element containing a textarea that grows in height as more
@@ -62,17 +62,13 @@ to notify this element the value has changed.
       box-shadow: none;
     }
 
-    .textarea-container {
-      @apply(--layout-fit);
-    }
-
   </style>
   <template>
     <!-- the mirror sizes the input/textarea so it grows with typing -->
     <div id="mirror" class="mirror-text" aria-hidden="true">&nbsp;</div>
 
     <!-- size the input/textarea with a div, because the textarea has intrinsic size in ff -->
-    <div class="textarea-container">
+    <div class="textarea-container fit">
       <content id="textarea" select="textarea"></content>
     </div>
   </template>


### PR DESCRIPTION
The mixin doesn't seem to work when the textarea is used inside a `paper-input-container`, but I don't understand why. In any case, using the class fixes it.

:point_right: @cdata @morethanreal 