### PR TITLE
Fix attached() to copy from this.textarea.value

### DIFF
--- a/iron-autogrow-textarea.html
+++ b/iron-autogrow-textarea.html
@@ -150,7 +150,7 @@ to notify this element the value has changed.
     },
 
     attached: function() {
-      this.bindValue = this.value;
+      this.bindValue = this.textarea.value;
     },
 
     _bindValueChanged: function() {

--- a/test/basic.html
+++ b/test/basic.html
@@ -36,6 +36,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       </template>
     </test-fixture>
 
+    <test-fixture id="basic-attached">
+      <template>
+        <div id="insert">
+        </div>
+      </template>
+    </test-fixture>
+
     <script>
 
       suite('basic', function() {
@@ -75,6 +82,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           autogrow.bindValue = 'batman';
           var finalHeight = autogrow.offsetHeight
           assert.isTrue(finalHeight < initialHeight);
+        });
+
+        test('bindValue gets initial textarea value when attached to the DOM', function() {
+          var insertDiv = fixture('basic-attached');
+          var html = "<iron-autogrow-textarea><textarea>batman</textarea></iron-autogrow-textarea>";
+          insertDiv.innerHTML = html;
+
+          var textarea = insertDiv.querySelector('textarea');
+          var autogrow = insertDiv.querySelector('iron-autogrow-textarea');
+          assert.equal(textarea.value, 'batman', 'textarea value equals its content');
+          assert.equal(autogrow.bindValue, textarea.value, 'bindValue equals textarea value after an attach');
         });
       });
 


### PR DESCRIPTION
instead of this.value (which isn't a valid property), resulting in the binding getting set to `undefined` instead of the actual value of the textarea when the element is attached to the DOM.