### PR TITLE
Fit initial textarea content

### DIFF
--- a/iron-autogrow-textarea.html
+++ b/iron-autogrow-textarea.html
@@ -150,7 +150,7 @@ to notify this element the value has changed.
     },
 
     attached: function() {
-      this.bindValue = this.value;
+      this.bindValue = this.textarea.value;
     },
 
     _bindValueChanged: function() {

--- a/iron-autogrow-textarea.html
+++ b/iron-autogrow-textarea.html
@@ -150,7 +150,7 @@ to notify this element the value has changed.
     },
 
     attached: function() {
-      this.bindValue = this.textarea.value;
+      this.update();
     },
 
     _bindValueChanged: function() {

--- a/test/basic.html
+++ b/test/basic.html
@@ -36,10 +36,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       </template>
     </test-fixture>
 
-    <test-fixture id="basic-attached">
+    <test-fixture id="basic-prefilled">
       <template>
-        <div id="insert">
-        </div>
+        <iron-autogrow-textarea>
+<textarea>
+batman
+and
+robin
+</textarea>
+        </iron-autogrow-textarea>
       </template>
     </test-fixture>
 
@@ -84,15 +89,21 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           assert.isTrue(finalHeight < initialHeight);
         });
 
-        test('bindValue gets initial textarea value when attached to the DOM', function() {
-          var insertDiv = fixture('basic-attached');
-          var html = "<iron-autogrow-textarea><textarea>batman</textarea></iron-autogrow-textarea>";
-          insertDiv.innerHTML = html;
+        test('bindValue gets initial textarea content', function() {
+          var autogrow = fixture('basic-prefilled');
+          var textarea = autogrow.querySelector('textarea');
 
-          var textarea = insertDiv.querySelector('textarea');
-          var autogrow = insertDiv.querySelector('iron-autogrow-textarea');
-          assert.equal(textarea.value, 'batman', 'textarea value equals its content');
-          assert.equal(autogrow.bindValue, textarea.value, 'bindValue equals textarea value after an attach');
+          assert.equal(textarea.value, 'batman\nand\nrobin\n', 'textarea value equals its content');
+          assert.equal(autogrow.bindValue, textarea.value, 'bindValue equals initial textarea value');
+        });
+
+        test('textarea grows to fit its initial content', function() {
+          var autogrow = fixture('basic');
+          var initialHeight = autogrow.offsetHeight;
+          var prefilledAutogrow = fixture('basic-prefilled');
+          var prefilledHeight = prefilledAutogrow.offsetHeight;
+
+          assert.isTrue(prefilledHeight > initialHeight);
         });
       });
 

--- a/test/basic.html
+++ b/test/basic.html
@@ -36,6 +36,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       </template>
     </test-fixture>
 
+    <test-fixture id="basic-attached">
+      <template>
+        <div id="insert">
+        </div>
+      </template>
+    </test-fixture>
+
     <script>
 
       suite('basic', function() {
@@ -75,6 +82,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           autogrow.bindValue = 'batman';
           var finalHeight = autogrow.offsetHeight
           assert.isTrue(finalHeight < initialHeight);
+        });
+
+        test('bindValue gets initial textarea value when attached to the DOM', function() {
+          var insertDiv = fixture('basic-attached');
+          var html = "<iron-autogrow-textarea><textarea>batman</textarea></iron-autogrow-textarea>";
+          insertDiv.innerHTML = html;
+
+          var textarea = insertDiv.querySelector('textarea');
+          var autogrow = insertDiv.querySelector('iron-autogrow-textarea');
+          assert.equal(textarea.value, 'batman', 'textarea value equals its content');
+          assert.equal(autogrow.bindValue, textarea.value, 'bindValue equals textarea value after an attach');
         });
       });
 


### PR DESCRIPTION
If the textarea has initial content, iron-autogrow-textarea doesn't set its bindValue accordingly, or grow the textarea to fit it.

This PR fixes these issues by calling update() in the attached() callback. 

It also add a test to check that bindValue is getting the initial textarea content, and a test to check that the textarea grows to fit its initial content.