### PR TITLE
fix #6 Doesn't initialize properly with textarea content

### DIFF
--- a/iron-autogrow-textarea.html
+++ b/iron-autogrow-textarea.html
@@ -150,7 +150,7 @@ to notify this element the value has changed.
     },
 
     attached: function() {
-      this.bindValue = this.value;
+      this.update();
     },
 
     _bindValueChanged: function() {

--- a/test/basic.html
+++ b/test/basic.html
@@ -36,9 +36,29 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       </template>
     </test-fixture>
 
+    <test-fixture id="basic-prefilled">
+      <template>
+        <iron-autogrow-textarea>
+<textarea>
+batman
+and
+robin
+</textarea>
+        </iron-autogrow-textarea>
+      </template>
+    </test-fixture>
+
     <script>
 
       suite('basic', function() {
+
+        test('initial bindValue not undefined for empty textarea', function() {
+          var autogrow = fixture('basic');
+          var textarea = autogrow.querySelector('textarea');
+
+          assert.notEqual(textarea.value, undefined, 'empty textarea value is not undefined');
+          assert.notEqual(autogrow.bindValue, undefined, 'autogrow bindValue for empty textarea is not undefined');
+        });
 
         test('setting bindValue sets textarea value', function() {
           var autogrow = fixture('basic');
@@ -75,6 +95,23 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           autogrow.bindValue = 'batman';
           var finalHeight = autogrow.offsetHeight
           assert.isTrue(finalHeight < initialHeight);
+        });
+
+        test('bindValue gets initial textarea content', function() {
+          var autogrow = fixture('basic-prefilled');
+          var textarea = autogrow.querySelector('textarea');
+
+          assert.equal(textarea.value, 'batman\nand\nrobin\n', 'textarea value equals its content');
+          assert.equal(autogrow.bindValue, textarea.value, 'bindValue equals initial textarea value');
+        });
+
+        test('textarea grows to fit its initial content', function() {
+          var autogrow = fixture('basic');
+          var initialHeight = autogrow.offsetHeight;
+          var prefilledAutogrow = fixture('basic-prefilled');
+          var prefilledHeight = prefilledAutogrow.offsetHeight;
+
+          assert.isTrue(prefilledHeight > initialHeight);
         });
       });
 


### PR DESCRIPTION
Fix iron-autogrow-textarea to set bindValue with the initial textarea content instead of `undefined`, and to resize the textarea to fit initial content.