### PR TITLE
include textarea in local dom

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -24,10 +24,11 @@
   "ignore": [],
   "dependencies": {
     "iron-flex-layout": "PolymerElements/iron-flex-layout#^0.9.0",
+    "iron-validatable-behavior": "PolymerElements/iron-validatable-behavior#^0.9.0",
     "polymer": "Polymer/polymer#^0.9.0"
   },
   "devDependencies": {
-    "iron-doc-viewer": "PolymerElements/iron-doc-viewer#^0.9.0",
+    "iron-component-page": "PolymerElements/iron-component-page#^0.9.0",
     "test-fixture": "PolymerElements/test-fixture#^0.9.0",
     "web-component-tester": "Polymer/web-component-tester#^2.2.3",
     "paper-styles": "PolymerElements/paper-styles#^0.9.0",

--- a/demo/index.html
+++ b/demo/index.html
@@ -34,9 +34,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <template is="dom-bind">
       <section>
         <div>Updating the value imperatively</div>
-        <iron-autogrow-textarea bind-value="{{bindValue}}" id="a1">
-          <textarea id="t1">asdfasdfasdfad</textarea>
-        </iron-autogrow-textarea>
+        <iron-autogrow-textarea bind-value="{{bindValue}}" id="a1"></iron-autogrow-textarea>
         <br><br>
 
         <code>bind-value</code>: <span>[[bindValue]]</span>
@@ -56,16 +54,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <section>
       <div>Scrolls after 4 rows</div>
-      <iron-autogrow-textarea max-rows="4">
-        <textarea></textarea>
-      </iron-autogrow-textarea>
+      <iron-autogrow-textarea max-rows="4"></iron-autogrow-textarea>
     </section>
 
     <section>
       <div>Initial height of 4 rows</div>
-      <iron-autogrow-textarea rows="4">
-        <textarea></textarea>
-      </iron-autogrow-textarea>
+      <iron-autogrow-textarea rows="4"></iron-autogrow-textarea>
     </section>
 
     <script>
@@ -79,8 +73,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         if (event.target.value == "bindValue") {
           document.querySelector('iron-autogrow-textarea').bindValue = inputValue;
         } else {
-          document.querySelector('textarea').value = inputValue;
-          document.querySelector('iron-autogrow-textarea').update();
+          document.querySelector('iron-autogrow-textarea').textarea.value = inputValue;
         }
 
       }

--- a/index.html
+++ b/index.html
@@ -19,12 +19,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <script src="../webcomponentsjs/webcomponents-lite.js"></script>
 
     <link rel="import" href="../polymer/polymer.html">
-    <link rel="import" href="../iron-doc-viewer/iron-doc-viewer.html">
+    <link rel="import" href="../iron-component-page/iron-component-page.html">
 
   </head>
   <body>
 
-    <iron-doc-viewer></iron-doc-viewer>
+    <iron-component-page></iron-component-page>
 
   </body>
 </html>

--- a/iron-autogrow-textarea.html
+++ b/iron-autogrow-textarea.html
@@ -10,6 +10,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../iron-flex-layout/classes/iron-flex-layout.html">
+<link rel="import" href="../iron-validatable-behavior/iron-validatable-behavior.html">
 
 <!--
 `iron-autogrow-textarea` is an element containing a textarea that grows in height as more
@@ -23,17 +24,7 @@ Example:
     </iron-autogrow-textarea>
 
 Because the `textarea`'s `value` property is not observable, you should use
-this element's `bind-value` instead for imperative updates. Alternatively, if
-you do set the `textarea`'s `value` imperatively, you must also call `update`
-to notify this element the value has changed.
-
-    Example:
-        /* preferred, using the example HTML above*/
-        a1.bindValue = 'some\ntext';
-
-        /* alternatively, */
-        t1.value = 'some\ntext';
-        a1.update();
+this element's `bind-value` instead for imperative updates.
 
 @group Iron Elements
 @hero hero.svg
@@ -41,11 +32,16 @@ to notify this element the value has changed.
 -->
 
 <dom-module id="iron-autogrow-textarea">
+
   <style>
     :host {
       display: inline-block;
       position: relative;
       width: 400px;
+      border: 1px solid;
+      padding: 2px;
+      -moz-appearance: textarea;
+      -webkit-appearance: textarea;
     }
 
     .mirror-text {
@@ -53,8 +49,12 @@ to notify this element the value has changed.
       word-wrap: break-word;
     }
 
-    ::content textarea {
+    textarea {
+      position: relative;
+      outline: none;
+      border: none;
       resize: none;
+      background: inherit;
       /* see comments in template */
       width: 100%;
       height: 100%;
@@ -73,7 +73,7 @@ to notify this element the value has changed.
 
     <!-- size the input/textarea with a div, because the textarea has intrinsic size in ff -->
     <div class="textarea-container fit">
-      <content id="textarea" select="textarea"></content>
+      <textarea id="textarea" required$="[[required]]" rows$="[[rows]]" maxlength$="[[maxlength]]"></textarea>
     </div>
   </template>
 
@@ -82,6 +82,10 @@ to notify this element the value has changed.
   Polymer({
 
     is: 'iron-autogrow-textarea',
+
+    behaviors: [
+      Polymer.IronValidatableBehavior
+    ],
 
     properties: {
 
@@ -115,10 +119,25 @@ to notify this element the value has changed.
        * @default 0
        */
       maxRows: {
-         type: Number,
-         value: 0,
-         observer: '_updateCached'
+       type: Number,
+       value: 0,
+       observer: '_updateCached'
+      },
+
+      /**
+       * Set to true to mark the textarea as required.
+       */
+      required: {
+        type: Boolean
+      },
+
+      /**
+       * The maximum length of the input value.
+       */
+      maxlength: {
+        type: Number
       }
+
     },
 
     listeners: {
@@ -127,22 +146,12 @@ to notify this element the value has changed.
 
     /**
      * Returns the underlying textarea.
-     *
-     * @property textarea
-     * @type Element
      */
     get textarea() {
-      return Polymer.dom(this.$.textarea).getDistributedNodes()[0];
+      return this.$.textarea;
     },
 
-    /**
-     * Sizes this element to fit the input value. This function is automatically called
-     * when the user types in new input, but you must call this function if the value
-     * is updated imperatively.
-     *
-     * @method update
-     */
-    update: function() {
+    _update: function() {
       this.$.mirror.innerHTML = this._valueForMirror();
 
       var textarea = this.textarea;
@@ -164,14 +173,14 @@ to notify this element the value has changed.
       }
 
       textarea.value = this.bindValue;
-      this.update();
+      this._update();
       // manually notify because we don't want to notify until after setting value
       this.fire('bind-value-changed', {value: this.bindValue});
     },
 
     _onInput: function(event) {
-      this.bindValue = event.target.value;
-      this.update();
+      this.bindValue = event.path ? event.path[0].value : event.target.value;
+      this._update();
     },
 
     _constrain: function(tokens) {

--- a/test/basic.html
+++ b/test/basic.html
@@ -30,9 +30,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <test-fixture id="basic">
       <template>
-        <iron-autogrow-textarea>
-          <textarea></textarea>
-        </iron-autogrow-textarea>
+        <iron-autogrow-textarea></iron-autogrow-textarea>
+      </template>
+    </test-fixture>
+
+    <test-fixture id="rows">
+      <template>
+        <iron-autogrow-textarea rows="3"></iron-autogrow-textarea>
       </template>
     </test-fixture>
 
@@ -42,20 +46,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         test('setting bindValue sets textarea value', function() {
           var autogrow = fixture('basic');
-          var textarea = autogrow.querySelector('textarea');
+          var textarea = autogrow.textarea;
 
           autogrow.bindValue = 'batman';
           assert.equal(textarea.value, autogrow.bindValue, 'textarea value equals to bindValue');
         });
 
-        test('textarea value sets bindValue after update', function() {
-          var autogrow = fixture('basic');
-          var textarea = autogrow.querySelector('textarea');
-
-          textarea.value = 'batman';
-          autogrow.update();
-
-          assert.equal(textarea.value, autogrow.bindValue, 'textarea value equals to bindValue');
+        test('can set an initial number of rows', function() {
+          var autogrow = fixture("rows");
+          assert.equal(autogrow.textarea.rows, 3, 'textarea has rows=3');
         });
 
         test('adding rows grows the textarea', function() {


### PR DESCRIPTION
This is simpler and paper-input-container can treat this element
as a custom input, instead of requiring special handling for
the split responsibilies between the textarea and the sizer.
textarea API is available via the textarea() getter.

@notwaldorf PTAL cc @cdata 