### PR TITLE
fix broken behaviour when included in an iron-form

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -26,6 +26,7 @@
     "iron-behaviors": "PolymerElements/iron-behaviors#^1.0.0",
     "iron-flex-layout": "PolymerElements/iron-flex-layout#^1.0.0",
     "iron-validatable-behavior": "PolymerElements/iron-validatable-behavior#^1.0.0",
+    "iron-form-element-behavior": "PolymerElements/iron-form-element-behavior#^1.0.0",
     "polymer": "Polymer/polymer#^1.0.0"
   },
   "devDependencies": {

--- a/iron-autogrow-textarea.html
+++ b/iron-autogrow-textarea.html
@@ -12,6 +12,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../iron-behaviors/iron-control-state.html">
 <link rel="import" href="../iron-flex-layout/classes/iron-flex-layout.html">
 <link rel="import" href="../iron-validatable-behavior/iron-validatable-behavior.html">
+<link rel="import" href="../iron-form-element-behavior/iron-form-element-behavior.html">
 
 <!--
 `iron-autogrow-textarea` is an element containing a textarea that grows in height as more
@@ -78,7 +79,6 @@ this element's `bind-value` instead for imperative updates.
         autocomplete$="[[autocomplete]]"
         autofocus$="[[autofocus]]"
         inputmode$="[[inputmode]]"
-        name$="[[name]]"
         placeholder$="[[placeholder]]"
         readonly$="[[readonly]]"
         required$="[[required]]"
@@ -95,6 +95,7 @@ this element's `bind-value` instead for imperative updates.
     is: 'iron-autogrow-textarea',
 
     behaviors: [
+      Polymer.IronFormElementBehavior,
       Polymer.IronValidatableBehavior,
       Polymer.IronControlState
     ],
@@ -167,6 +168,15 @@ this element's `bind-value` instead for imperative updates.
       },
 
       /**
+       * The value for this input, same as `bindValue`
+       */
+      value: {
+        notify: true,
+        type: String,
+        computed: '_computeValue(bindValue)'
+      },
+
+      /**
        * Bound to the textarea's `placeholder` attribute.
        */
       placeholder: {
@@ -205,6 +215,30 @@ this element's `bind-value` instead for imperative updates.
      */
     get textarea() {
       return this.$.textarea;
+    },
+
+    /**
+     * Returns true if `value` is valid. The validator provided in `validator`
+     * will be used first, if it exists; otherwise, the `textarea`'s validity
+     * is used.
+     * @return {boolean} True if the value is valid.
+     */
+    validate: function() {
+      // Empty, non-required input is valid.
+      if (!this.required && this.value == '') {
+        this.invalid = false;
+        return true;
+      }
+
+      var valid;
+      if (this.hasValidator()) {
+        valid = Polymer.IronValidatableBehavior.validate.call(this, this.value);
+      } else {
+        valid = this.$.textarea.validity.valid;
+        this.invalid = !valid;
+      }
+      this.fire('iron-input-validate');
+      return valid;
     },
 
     _update: function() {
@@ -261,6 +295,10 @@ this element's `bind-value` instead for imperative updates.
 
     _updateCached: function() {
       this.$.mirror.innerHTML = this._constrain(this.tokens);
+    },
+
+    _computeValue: function() {
+      return this.bindValue;
     }
   })
 </script>

--- a/test/basic.html
+++ b/test/basic.html
@@ -120,6 +120,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       });
 
+      suite('validation', function() {
+        test('a required textarea with no text is invalid', function() {
+          var input = fixture('basic');
+          input.required = true;
+          assert.isFalse(input.validate());
+
+          input.bindValue = 'batman';
+          assert.isTrue(input.validate());
+        });
+      });
+
     </script>
 
   </body>


### PR DESCRIPTION
To make this work in an `iron-form` correctly (https://github.com/PolymerElements/iron-form/issues/12):
- added the `iron-form-element-behaviour` and a `value` property, to be used in serializing. It just mirrors `bind-value`, which I think is vestigial property naming from the days when this element was actually a `<textarea is="iron-textarea">`
- added a `validate()` method, mirrored after `iron-input`. Since `iron-autogrow-textarea` almost never has a validator set, it wasn't really getting validated at all.

The only reason why the `iron-autogrow-textarea` cared about `name` is because it magically worked in an `iron-form`. However, since it's a custom element, we process it's value separately, and don't need to pass it down to the `textarea`. If we do pass it down to the `textarea` then this will be processed twice, since we can't easily differentiate between a textarea that lives inside a `paper-textarea` and a plain boring textarea.

Anyway, the only thing this will break is that `iron-autogrow-textarea` can't be used in a native form, which to be fair is true of all custom elements, so I think it's fine.

Once this lands, we need to remove the `iron-form-element-behaviour` from `paper-textarea`, so that the latter doesn't get added to a form twice: https://github.com/PolymerElements/paper-input/pull/109