### PR TITLE
updated autofocus property so it defaults to null

### DIFF
--- a/iron-autogrow-textarea.html
+++ b/iron-autogrow-textarea.html
@@ -149,7 +149,6 @@ this element's `bind-value` instead for imperative updates.
        */
       autofocus: {
         type: String,
-        value: 'off'
       },
 
       /**


### PR DESCRIPTION
Setting autofocus="off" was causing the textarea to be autofocused (since autofocus doesn't have a disabled setting, it either exists or doesn't), so I removed the default value of "off".