### PR TITLE
Adds a semicolon after the Polymer call.

### DIFF
--- a/iron-autogrow-textarea.html
+++ b/iron-autogrow-textarea.html
@@ -302,5 +302,5 @@ this element's `bind-value` instead for imperative updates.
     _computeValue: function() {
       return this.bindValue;
     }
-  })
+  });
 </script>


### PR DESCRIPTION
When building a binary using Crisper this caused issues since the next code was wrapped in parens a-la
```
(function() { foo; })();
```
which ultimately called the iron-autogrow-textarea constructor, causing an exception.