### PR TITLE
inherit line-height

### DIFF
--- a/iron-autogrow-textarea.html
+++ b/iron-autogrow-textarea.html
@@ -63,6 +63,7 @@ this element's `bind-value` instead for imperative updates.
       height: 100%;
       font-size: inherit;
       font-family: inherit;
+      line-height: inherit;
     }
 
     ::content textarea:invalid {


### PR DESCRIPTION
`textarea` should inherit `line-height` in order to grow precisely