### PR TITLE
Remove _update & inline into _bindValueChanged

### DIFF
--- a/iron-autogrow-textarea.html
+++ b/iron-autogrow-textarea.html
@@ -244,17 +244,6 @@ this element's `bind-value` instead for imperative updates.
       return valid;
     },
 
-    _update: function() {
-      this.$.mirror.innerHTML = this._valueForMirror();
-
-      var textarea = this.textarea;
-      // If the value of the textarea was updated imperatively, then we
-      // need to manually update bindValue as well.
-      if (textarea && this.bindValue != textarea.value) {
-        this.bindValue = textarea.value;
-      }
-    },
-
     _bindValueChanged: function() {
       var textarea = this.textarea;
       if (!textarea) {
@@ -262,14 +251,13 @@ this element's `bind-value` instead for imperative updates.
       }
 
       textarea.value = this.bindValue;
-      this._update();
+      this.$.mirror.innerHTML = this._valueForMirror();
       // manually notify because we don't want to notify until after setting value
       this.fire('bind-value-changed', {value: this.bindValue});
     },
 
     _onInput: function(event) {
       this.bindValue = event.path ? event.path[0].value : event.target.value;
-      this._update();
     },
 
     _constrain: function(tokens) {


### PR DESCRIPTION
Previously, `_onInput` called `_update` after setting `bindValue`. But setting `bindValue` triggers `_bindValueChanged`, which calls `_update` too, so it's called twice.

After removing the call from `_onInput`, there was only one callsite left (and I assume that no other files use it), so I inlined `_update` (minus a now unnecessary check).