### PR TITLE
Define autofocus as boolean property

### DIFF
--- a/iron-autogrow-textarea.html
+++ b/iron-autogrow-textarea.html
@@ -151,8 +151,8 @@ this element's `bind-value` instead for imperative updates.
        * Bound to the textarea's `autofocus` attribute.
        */
       autofocus: {
-        type: String,
-        value: 'off'
+        type: Boolean,
+        value: false
       },
 
       /**


### PR DESCRIPTION
According to [W3C](http://www.w3.org/TR/html5/forms.html#attr-fe-autofocus), `autofocus` is a boolean attribute. Using "off" as default value, the `textarea` is actually with `autofocus`. The default value should be boolean false to prevent default autofocus behavior.

Fixes #17