### PR TITLE
Pass focus() to Input

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -56,7 +56,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         <p>Scrolls after 4 rows:</p>
         <iron-autogrow-textarea max-rows="4"></iron-autogrow-textarea>
         <p>Initial height of 4 rows</p>
-        <iron-autogrow-textarea rows="4"></iron-autogrow-textarea>
+        <iron-autogrow-textarea rows="4" id="textareaForFocus"></iron-autogrow-textarea>
+        <br>
+        <button onclick="textareaFocus()">Focus!</button>
       </div>
     </div>
 
@@ -74,6 +76,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           document.querySelector('iron-autogrow-textarea').textarea.value = inputValue;
         }
 
+      }
+
+      function textareaFocus () {
+        document.getElementById('textareaForFocus').focus();
       }
     </script>
 

--- a/iron-autogrow-textarea.html
+++ b/iron-autogrow-textarea.html
@@ -12,6 +12,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../iron-behaviors/iron-control-state.html">
 <link rel="import" href="../iron-flex-layout/classes/iron-flex-layout.html">
 <link rel="import" href="../iron-validatable-behavior/iron-validatable-behavior.html">
+<link rel="import" href="../iron-form-element-behavior/iron-form-element-behavior.html">
 
 <!--
 `iron-autogrow-textarea` is an element containing a textarea that grows in height as more
@@ -20,9 +21,7 @@ never scroll.
 
 Example:
 
-    <iron-autogrow-textarea id="a1">
-      <textarea id="t1"></textarea>
-    </iron-autogrow-textarea>
+    <iron-autogrow-textarea></iron-autogrow-textarea>
 
 Because the `textarea`'s `value` property is not observable, you should use
 this element's `bind-value` instead for imperative updates.
@@ -56,11 +55,13 @@ this element's `bind-value` instead for imperative updates.
       border: none;
       resize: none;
       background: inherit;
+      color: inherit;
       /* see comments in template */
       width: 100%;
       height: 100%;
       font-size: inherit;
       font-family: inherit;
+      line-height: inherit;
     }
 
     ::content textarea:invalid {
@@ -78,7 +79,6 @@ this element's `bind-value` instead for imperative updates.
         autocomplete$="[[autocomplete]]"
         autofocus$="[[autofocus]]"
         inputmode$="[[inputmode]]"
-        name$="[[name]]"
         placeholder$="[[placeholder]]"
         readonly$="[[readonly]]"
         required$="[[required]]"
@@ -95,6 +95,7 @@ this element's `bind-value` instead for imperative updates.
     is: 'iron-autogrow-textarea',
 
     behaviors: [
+      Polymer.IronFormElementBehavior,
       Polymer.IronValidatableBehavior,
       Polymer.IronControlState
     ],
@@ -148,8 +149,8 @@ this element's `bind-value` instead for imperative updates.
        * Bound to the textarea's `autofocus` attribute.
        */
       autofocus: {
-        type: String,
-        value: 'off'
+        type: Boolean,
+        value: false
       },
 
       /**
@@ -164,6 +165,15 @@ this element's `bind-value` instead for imperative updates.
        */
       name: {
         type: String
+      },
+
+      /**
+       * The value for this input, same as `bindValue`
+       */
+      value: {
+        notify: true,
+        type: String,
+        computed: '_computeValue(bindValue)'
       },
 
       /**
@@ -202,20 +212,41 @@ this element's `bind-value` instead for imperative updates.
 
     /**
      * Returns the underlying textarea.
+     * @type HTMLTextAreaElement
      */
     get textarea() {
       return this.$.textarea;
     },
 
-    _update: function() {
-      this.$.mirror.innerHTML = this._valueForMirror();
+    /**
+     * Passes focus() to the textarea element
+     */
+    focus: function() {
+      this.$.textarea.focus();
+    },
 
-      var textarea = this.textarea;
-      // If the value of the textarea was updated imperatively, then we
-      // need to manually update bindValue as well.
-      if (textarea && this.bindValue != textarea.value) {
-        this.bindValue = textarea.value;
+    /**
+     * Returns true if `value` is valid. The validator provided in `validator`
+     * will be used first, if it exists; otherwise, the `textarea`'s validity
+     * is used.
+     * @return {boolean} True if the value is valid.
+     */
+    validate: function() {
+      // Empty, non-required input is valid.
+      if (!this.required && this.value == '') {
+        this.invalid = false;
+        return true;
       }
+
+      var valid;
+      if (this.hasValidator()) {
+        valid = Polymer.IronValidatableBehavior.validate.call(this, this.value);
+      } else {
+        valid = this.$.textarea.validity.valid;
+        this.invalid = !valid;
+      }
+      this.fire('iron-input-validate');
+      return valid;
     },
 
     _bindValueChanged: function() {
@@ -225,14 +256,13 @@ this element's `bind-value` instead for imperative updates.
       }
 
       textarea.value = this.bindValue;
-      this._update();
+      this.$.mirror.innerHTML = this._valueForMirror();
       // manually notify because we don't want to notify until after setting value
       this.fire('bind-value-changed', {value: this.bindValue});
     },
 
     _onInput: function(event) {
       this.bindValue = event.path ? event.path[0].value : event.target.value;
-      this._update();
     },
 
     _constrain: function(tokens) {
@@ -261,6 +291,10 @@ this element's `bind-value` instead for imperative updates.
 
     _updateCached: function() {
       this.$.mirror.innerHTML = this._constrain(this.tokens);
+    },
+
+    _computeValue: function() {
+      return this.bindValue;
     }
-  })
+  });
 </script>


### PR DESCRIPTION
Added a function to pass the focus command to the textarea element.

Similar to this [pull request for paper-input](https://github.com/PolymerElements/paper-input/pull/162), but for the textarea.