### PR TITLE
make selectionStart and selectionEnd work

### DIFF
--- a/iron-autogrow-textarea.html
+++ b/iron-autogrow-textarea.html
@@ -219,6 +219,36 @@ this element's `bind-value` instead for imperative updates.
     },
 
     /**
+     * Returns textarea's selection start.
+     * @type Number
+     */
+    get selectionStart() {
+      return this.$.textarea.selectionStart;
+    },
+
+    /**
+     * Returns textarea's selection end.
+     * @type Number
+     */
+    get selectionEnd() {
+      return this.$.textarea.selectionEnd;
+    },
+
+    /**
+     * Sets the textarea's selection start.
+     */
+    set selectionStart(value) {
+      this.$.textarea.selectionStart = value;
+    },
+
+    /**
+     * Sets the textarea's selection end.
+     */
+    set selectionEnd(value) {
+      this.$.textarea.selectionEnd = value;
+    },
+
+    /**
      * Returns true if `value` is valid. The validator provided in `validator`
      * will be used first, if it exists; otherwise, the `textarea`'s validity
      * is used.

--- a/test/basic.html
+++ b/test/basic.html
@@ -87,6 +87,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           var finalHeight = autogrow.offsetHeight
           assert.isTrue(finalHeight < initialHeight);
         });
+
+        test('textarea selection works', function() {
+          var autogrow = fixture('basic');
+          var textarea = autogrow.textarea;
+          autogrow.bindValue = 'batman\nand\nrobin';
+
+          autogrow.selectionStart = 3;
+          autogrow.selectionEnd = 5;
+
+          assert.equal(textarea.selectionStart, 3);
+          assert.equal(textarea.selectionEnd, 5);
+        });
       });
 
       suite('focus/blur events', function() {


### PR DESCRIPTION
:balloon: @cdata 

I don't think `selectionStart` is accessible as an attribute, so I've added getters/setters to pass it down to the textarea. It's needed to make the `paper-input` tests pass (see https://github.com/PolymerElements/paper-input/pull/151)
