### PR TITLE
remove dependencies to deprecated layout

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -24,7 +24,6 @@
   "ignore": [],
   "dependencies": {
     "iron-behaviors": "PolymerElements/iron-behaviors#^1.0.0",
-    "iron-flex-layout": "PolymerElements/iron-flex-layout#^1.0.0",
     "iron-validatable-behavior": "PolymerElements/iron-validatable-behavior#^1.0.0",
     "iron-form-element-behavior": "PolymerElements/iron-form-element-behavior#^1.0.0",
     "polymer": "Polymer/polymer#^1.0.0"

--- a/bower.json
+++ b/bower.json
@@ -24,6 +24,7 @@
   "ignore": [],
   "dependencies": {
     "iron-behaviors": "PolymerElements/iron-behaviors#^1.0.0",
+    "iron-flex-layout": "PolymerElements/iron-flex-layout#^1.0.0",
     "iron-validatable-behavior": "PolymerElements/iron-validatable-behavior#^1.0.0",
     "iron-form-element-behavior": "PolymerElements/iron-form-element-behavior#^1.0.0",
     "polymer": "Polymer/polymer#^1.0.0"

--- a/iron-autogrow-textarea.html
+++ b/iron-autogrow-textarea.html
@@ -10,6 +10,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../iron-behaviors/iron-control-state.html">
+<link rel="import" href="../iron-flex-layout/iron-flex-layout.html">
 <link rel="import" href="../iron-validatable-behavior/iron-validatable-behavior.html">
 <link rel="import" href="../iron-form-element-behavior/iron-form-element-behavior.html">
 
@@ -49,11 +50,7 @@ this element's `bind-value` instead for imperative updates.
     }
     
     .fit {
-      position: absolute;
-      top: 0;
-      bottom: 0;
-      left: 0;
-      right: 0;
+      @apply(--layout-fit);
     }
 
     textarea {

--- a/iron-autogrow-textarea.html
+++ b/iron-autogrow-textarea.html
@@ -10,7 +10,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../iron-behaviors/iron-control-state.html">
-<link rel="import" href="../iron-flex-layout/classes/iron-flex-layout.html">
 <link rel="import" href="../iron-validatable-behavior/iron-validatable-behavior.html">
 <link rel="import" href="../iron-form-element-behavior/iron-form-element-behavior.html">
 
@@ -47,6 +46,14 @@ this element's `bind-value` instead for imperative updates.
     .mirror-text {
       visibility: hidden;
       word-wrap: break-word;
+    }
+    
+    .fit {
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      left: 0;
+      right: 0;
     }
 
     textarea {


### PR DESCRIPTION
`iron-flex-layout` (precisely `iron-flex-shadow-layout`) uses the deprecated `/deep/` combinator;
this repo uses `iron-flex-layout` just for the css rule set of the `.fit` selector;
copy that rule set and remove the dependency.