### PR TITLE
Bind disabled attribute

### DIFF
--- a/iron-autogrow-textarea.html
+++ b/iron-autogrow-textarea.html
@@ -82,6 +82,7 @@ this element's `bind-value` instead for imperative updates.
         placeholder$="[[placeholder]]"
         readonly$="[[readonly]]"
         required$="[[required]]"
+        disabled$="[[disabled]]"
         rows$="[[rows]]"
         maxlength$="[[maxlength]]"></textarea>
     </div>


### PR DESCRIPTION
Added an attribute to the textarea to pass the disabled state of iron-autogrow-textarea.

Without this, the textarea is still focusable via javascript.