### PR TITLE
fix double saving of values

### DIFF
--- a/iron-autogrow-textarea.html
+++ b/iron-autogrow-textarea.html
@@ -286,7 +286,14 @@ Custom property | Description | Default
         return;
       }
 
-      textarea.value = this.bindValue;
+      // If the bindValue changed manually, then we need to also update
+      // the underlying textarea's value. Otherwise this change was probably
+      // generated from the _onInput handler, and the two values are already
+      // the same.
+      if (textarea.value !== this.bindValue) {
+        textarea.value = this.bindValue;
+      }
+
       this.$.mirror.innerHTML = this._valueForMirror();
       // manually notify because we don't want to notify until after setting value
       this.fire('bind-value-changed', {value: this.bindValue});


### PR DESCRIPTION
Fixes https://github.com/PolymerElements/iron-autogrow-textarea/issues/39

Double-updating the underlying textarea's value has no effect on desktop. However, on swipe keyboards, the final value isn't actually committed when we update it like this, so we lose un-committed words.

/cc @azakus 