### PR TITLE
treat undefined like the empty string

### DIFF
--- a/iron-autogrow-textarea.html
+++ b/iron-autogrow-textarea.html
@@ -291,7 +291,7 @@ Custom property | Description | Default
       // generated from the _onInput handler, and the two values are already
       // the same.
       if (textarea.value !== this.bindValue) {
-        textarea.value = this.bindValue;
+        textarea.value = !(this.bindValue || this.bindValue === 0) ? '' : this.bindValue;
       }
 
       this.$.mirror.innerHTML = this._valueForMirror();

--- a/test/basic.html
+++ b/test/basic.html
@@ -88,6 +88,19 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           assert.isTrue(finalHeight < initialHeight);
         });
 
+        test('an undefined bindValue is the empty string', function() {
+          var autogrow = fixture('basic');
+          var initialHeight = autogrow.offsetHeight;
+
+          autogrow.bindValue = 'batman\nand\nrobin';
+          var finalHeight = autogrow.offsetHeight;
+          assert.isTrue(finalHeight > initialHeight);
+
+          autogrow.bindValue = undefined;
+          assert.equal(autogrow.offsetHeight, initialHeight);
+          assert.equal(autogrow.textarea.value, '');
+        });
+
         test('textarea selection works', function() {
           var autogrow = fixture('basic');
           var textarea = autogrow.textarea;


### PR DESCRIPTION
Fixes https://github.com/PolymerElements/iron-autogrow-textarea/issues/37

(and matches `iron-input`'s logic in `_bindValueChanged`)