### PR TITLE
use xhtml friendly spaces

### DIFF
--- a/iron-autogrow-textarea.html
+++ b/iron-autogrow-textarea.html
@@ -78,7 +78,8 @@ Custom property | Description | Default
   </style>
   <template>
     <!-- the mirror sizes the input/textarea so it grows with typing -->
-    <div id="mirror" class="mirror-text" aria-hidden="true">&nbsp;</div>
+    <!-- use &#160; instead &nbsp; of to allow this element to be used in XHTML -->
+    <div id="mirror" class="mirror-text" aria-hidden="true">&#160;</div>
 
     <!-- size the input/textarea with a div, because the textarea has intrinsic size in ff -->
     <div class="textarea-container fit">
@@ -112,7 +113,7 @@ Custom property | Description | Default
 
       /**
        * Use this property instead of `value` for two-way data binding.
-       * 
+       *
        * @type {string|number|undefined|null}
        */
       bindValue: {
@@ -317,7 +318,8 @@ Custom property | Description | Default
       while (this.rows > 0 && _tokens.length < this.rows) {
         _tokens.push('');
       }
-      return _tokens.join('<br>') + '&nbsp;';
+      // Use &#160; instead &nbsp; of to allow this element to be used in XHTML.
+      return _tokens.join('<br/>') + '&#160;';
     },
 
     _valueForMirror: function() {


### PR DESCRIPTION
Fixes https://github.com/PolymerElements/iron-autogrow-textarea/issues/47