### PR TITLE
text-align inherited for shadow dom case

### DIFF
--- a/iron-autogrow-textarea.html
+++ b/iron-autogrow-textarea.html
@@ -72,6 +72,7 @@ Custom property | Description | Default
       font-size: inherit;
       font-family: inherit;
       line-height: inherit;
+      text-align: inherit;
       @apply(--iron-autogrow-textarea);
     }
 
@@ -116,7 +117,7 @@ Custom property | Description | Default
 
       /**
        * Use this property instead of `value` for two-way data binding.
-       * 
+       *
        * @type {string|number|undefined|null}
        */
       bindValue: {


### PR DESCRIPTION
Needed by https://github.com/PolymerElements/paper-input/pull/216
This fix allows textarea's <code>text-align</code> to be inherited.