### PR TITLE
fix: pass "name" attribute to native textarea

### DIFF
--- a/iron-autogrow-textarea.html
+++ b/iron-autogrow-textarea.html
@@ -89,6 +89,7 @@ Custom property | Description | Default
     <!-- size the input/textarea with a div, because the textarea has intrinsic size in ff -->
     <div class="textarea-container fit">
       <textarea id="textarea"
+        name$="[[name]]"
         autocomplete$="[[autocomplete]]"
         autofocus$="[[autofocus]]"
         inputmode$="[[inputmode]]"


### PR DESCRIPTION
iron-autogrow-textarea was forgetting to pass the `name` attribute it was created with along to the native textarea inside it, causing the browser to ignore its value when submitting a containing form.

closes PolymerElements/paper-input#239.