### PR TITLE
Fix broken growth behavior

### DIFF
--- a/iron-autogrow-textarea.html
+++ b/iron-autogrow-textarea.html
@@ -55,6 +55,7 @@ Custom property | Description | Default
     .mirror-text {
       visibility: hidden;
       word-wrap: break-word;
+      white-space: pre-wrap;
     }
 
     .fit {
@@ -75,6 +76,7 @@ Custom property | Description | Default
       font-family: inherit;
       line-height: inherit;
       text-align: inherit;
+      white-space: pre-wrap;
       @apply(--iron-autogrow-textarea);
     }
 


### PR DESCRIPTION
`white-space: pre-wrap` is added to preserve whitespace within the mirror. This was causing long lines without line breaks break in the `<textarea>` not in the mirror div.