### PR TITLE
fix  .mirror-text beyond the limit ( firefox 42.0 )

### DIFF
--- a/iron-autogrow-textarea.html
+++ b/iron-autogrow-textarea.html
@@ -54,7 +54,8 @@ Custom property | Description | Default
 
     .mirror-text {
       visibility: hidden;
-      word-wrap: break-word;
+      white-space: normal;
+      word-break: break-all;
     }
 
     .fit {


### PR DESCRIPTION
fix bug from issue:
https://github.com/PolymerElements/iron-autogrow-textarea/issues/62