### PR TITLE
Added mixin to style placeholder

### DIFF
--- a/iron-autogrow-textarea.html
+++ b/iron-autogrow-textarea.html
@@ -33,6 +33,7 @@ The following custom properties and mixins are available for styling:
 Custom property | Description | Default
 ----------------|-------------|----------
 `--iron-autogrow-textarea` | Mixin applied to the textarea | `{}`
+`--iron-autogrow-textarea-placeholder` | Mixin applied to the textarea placeholder | `{}`
 
 @group Iron Elements
 @hero hero.svg
@@ -82,6 +83,21 @@ Custom property | Description | Default
       box-shadow: none;
     }
 
+    textarea::-webkit-input-placeholder {
+      @apply(--iron-autogrow-textarea-placeholder);
+    }
+
+    textarea:-moz-placeholder {
+      @apply(--iron-autogrow-textarea-placeholder);
+    }
+
+    textarea::-moz-placeholder {
+      @apply(--iron-autogrow-textarea-placeholder);
+    }
+
+    textarea:-ms-input-placeholder {
+      @apply(--iron-autogrow-textarea-placeholder);
+    }
   </style>
   <template>
     <!-- the mirror sizes the input/textarea so it grows with typing -->


### PR DESCRIPTION
`<paper-input>` gets appropriate color styling to its native `input` element's placeholder.

https://github.com/PolymerElements/paper-input/blob/master/paper-input.html#L77-L91

`<paper-textarea>` doesn't because `<iron-autogrow-textarea>` doesn't support it. 

In order to spread the placeholder color love to `<paper-textarea>`, we need some mixins to get down and dirty with the native `textarea` element.

