### PR TITLE
make value semantic more similar to iron-input

### DIFF
--- a/iron-autogrow-textarea.html
+++ b/iron-autogrow-textarea.html
@@ -120,8 +120,6 @@ Custom property | Description | Default
 
       /**
        * Use this property instead of `value` for two-way data binding.
-       *
-       * @type {string|number|undefined|null}
        */
       bindValue: {
         observer: '_bindValueChanged',
@@ -191,6 +189,7 @@ Custom property | Description | Default
       value: {
         notify: true,
         type: String,
+        value: '',
         computed: '_computeValue(bindValue)'
       },
 
@@ -264,6 +263,10 @@ Custom property | Description | Default
      */
     set selectionEnd(value) {
       this.$.textarea.selectionEnd = value;
+    },
+	
+    ready: function() {
+      this.bindValue = this.value;
     },
 
     /**


### PR DESCRIPTION
Hi,
I noticed some differences between the value semantics of ```iron-input``` and ```iron-autogrow-textarea```.
* ```bindValue``` should not have a type definition of  ```{string|number|undefined|null}```. Cant think of a reason why one should allow other type than string here. This makes input validation unnecessarily complex.
* The default value for HTML-inputs and textareas is an empty string ```''``` instead of ```undefined```
* Adding ```ready``` to update ```bindValue```, this is related to https://github.com/PolymerElements/iron-input/issues/76. It fixes validation errors. JSBIN: http://jsbin.com/vetiwupele/1/edit?html,output .

Also see https://github.com/PolymerElements/paper-input/pull/315 .