### PR TITLE
Use the name attribute

### DIFF
--- a/iron-autogrow-textarea.html
+++ b/iron-autogrow-textarea.html
@@ -94,6 +94,7 @@ Custom property | Description | Default
         autocomplete$="[[autocomplete]]"
         autofocus$="[[autofocus]]"
         inputmode$="[[inputmode]]"
+        name$="[[name]]"
         placeholder$="[[placeholder]]"
         readonly$="[[readonly]]"
         required$="[[required]]"


### PR DESCRIPTION
The name attribute passed in to this element was previously unused, this
binds it to the underlying textarea as the documentation suggests it
should be.