### PR TITLE
fix drawing outside the border

### DIFF
--- a/iron-autogrow-textarea.html
+++ b/iron-autogrow-textarea.html
@@ -50,6 +50,7 @@ Custom property | Description | Default
       padding: 2px;
       -moz-appearance: textarea;
       -webkit-appearance: textarea;
+      overflow: hidden;
     }
 
     .mirror-text {


### PR DESCRIPTION
Fixes https://github.com/PolymerElements/iron-autogrow-textarea/issues/70

Before this PR, when setitng a max-height, the cursor could be drawn outside the element, which isn't great:
<img width="226" alt="screen shot 2016-01-27 at 8 01 55 pm" src="https://cloud.githubusercontent.com/assets/1369170/12635224/ea45b8e4-c535-11e5-8467-4a6c4e84a12a.png">

This fixes that.