### PR TITLE
Clean up `value` inherited form IronFormElementBehavior

### DIFF
--- a/iron-autogrow-textarea.html
+++ b/iron-autogrow-textarea.html
@@ -23,9 +23,6 @@ Example:
 
     <iron-autogrow-textarea></iron-autogrow-textarea>
 
-Because the `textarea`'s `value` property is not observable, you should use
-this element's `bind-value` instead for imperative updates.
-
 ### Styling
 
 The following custom properties and mixins are available for styling:
@@ -108,6 +105,7 @@ Custom property | Description | Default
     <!-- size the input/textarea with a div, because the textarea has intrinsic size in ff -->
     <div class="textarea-container fit">
       <textarea id="textarea"
+        name$="[[name]]"
         autocomplete$="[[autocomplete]]"
         autofocus$="[[autofocus]]"
         inputmode$="[[inputmode]]"
@@ -137,7 +135,7 @@ Custom property | Description | Default
 
       /**
        * Use this property instead of `value` for two-way data binding.
-       * 
+       * This property will be deprecated in the future. Use `value` instead.
        * @type {string|number}
        */
       bindValue: {
@@ -196,23 +194,6 @@ Custom property | Description | Default
       },
 
       /**
-       * Bound to the textarea's `name` attribute.
-       */
-      name: {
-        type: String
-      },
-
-      /**
-       * The value for this input, same as `bindValue`
-       */
-      value: {
-        notify: true,
-        type: String,
-        value: '',
-        computed: '_computeValue(bindValue)'
-      },
-
-      /**
        * Bound to the textarea's `placeholder` attribute.
        */
       placeholder: {
@@ -245,6 +226,10 @@ Custom property | Description | Default
     listeners: {
       'input': '_onInput'
     },
+
+    observers: [
+      '_onValueChanged(value)'
+    ],
 
     /**
      * Returns the underlying textarea.
@@ -282,10 +267,6 @@ Custom property | Description | Default
      */
     set selectionEnd(value) {
       this.$.textarea.selectionEnd = value;
-    },
-	
-    ready: function() {
-      this.bindValue = this.value;
     },
 
     /**
@@ -326,6 +307,7 @@ Custom property | Description | Default
         textarea.value = !(this.bindValue || this.bindValue === 0) ? '' : this.bindValue;
       }
 
+      this.value = this.bindValue;
       this.$.mirror.innerHTML = this._valueForMirror();
       // manually notify because we don't want to notify until after setting value
       this.fire('bind-value-changed', {value: this.bindValue});
@@ -364,8 +346,8 @@ Custom property | Description | Default
       this.$.mirror.innerHTML = this._constrain(this.tokens);
     },
 
-    _computeValue: function() {
-      return this.bindValue;
+    _onValueChanged: function() {
+      this.bindValue = this.value;
     }
   });
 </script>

--- a/test/basic.html
+++ b/test/basic.html
@@ -38,6 +38,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       </template>
     </test-fixture>
 
+    <test-fixture id="has-value">
+      <template>
+        <iron-autogrow-textarea value="foobar"></iron-autogrow-textarea>
+      </template>
+    </test-fixture>
+
     <test-fixture id="rows">
       <template>
         <iron-autogrow-textarea rows="3"></iron-autogrow-textarea>
@@ -59,6 +65,31 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         test('can set an initial bindValue', function() {
           var autogrow = fixture('has-bindValue');
           assert.equal(autogrow.textarea.value, 'foobar', 'textarea value equals to initial bindValue');
+          assert.equal(autogrow.value, 'foobar', 'value equals to initial bindValue');
+        });
+
+        test('can set an initial value', function() {
+          var autogrow = fixture('has-value');
+          assert.equal(autogrow.textarea.value, 'foobar', 'textarea value equals to initial bindValue');
+          assert.equal(autogrow.bindValue, 'foobar', 'textarea bindValue equals to initial value');
+        });
+
+        test('can update the value', function() {
+          var autogrow = fixture('has-bindValue');
+          assert.equal(autogrow.textarea.value, 'foobar', 'textarea value equals to initial bindValue');
+          autogrow.value = 'batman';
+          assert.equal(autogrow.textarea.value, 'batman', 'textarea value is updated');
+          assert.equal(autogrow.bindValue, 'batman', 'bindValue is updated');
+          assert.equal(autogrow.value, 'batman', 'value is updated');
+        });
+
+        test('can update the bindValue', function() {
+          var autogrow = fixture('has-bindValue');
+          assert.equal(autogrow.textarea.value, 'foobar', 'textarea value equals to initial bindValue');
+          autogrow.bindValue = 'batman';
+          assert.equal(autogrow.textarea.value, 'batman', 'textarea value is updated');
+          assert.equal(autogrow.bindValue, 'batman', 'bindValue is updated');
+          assert.equal(autogrow.value, 'batman', 'value is updated');
         });
 
         test('can set an initial number of rows', function() {


### PR DESCRIPTION
Fixes https://github.com/PolymerElements/iron-autogrow-textarea/issues/33

This is part of a 3-headed hydra of PRs that is trying to fix the following problem: `iron-form` was bad at de-duping nested elements with the same `name`, and would double submit them. The problem was that if you bind the `name` attribute all the way down, and these children you're binding it to are either native elements (so the form automatically cares about them) or custom elements with the `IronFormElementBehavior`, you would submit the same value twice.

To get around this, `paper-textarea` had a cheat where it wouldn't implement `IronFormElementBehavior`, its child, the `iron-autogrow-textarea` would, but to make sure that the nested `textarea` also didn't double submit, it didn't pass the `name` all the way down. This was crazy, and we can do better.

This PR cleans up `value`, which used to be readonly (because way back when this used to be a type extension, but we lost that and never cleaned up the code), and led to fun behavior such as:
<img width="123" alt="screen shot 2016-02-17 at 5 12 53 pm" src="https://cloud.githubusercontent.com/assets/1369170/13132733/4b66292c-d5aa-11e5-97c1-bb724018a0cb.png">

Landing this without the other 3 means that a `paper-textarea` will not be submitted correctly, and a standalone `iron-autogrow-textarea` will be submitted twice.

Related PRs:
- https://github.com/PolymerElements/paper-input/pull/342
- https://github.com/PolymerElements/iron-form/pull/110