### PR TITLE
Document that bindValue could be string or number

### DIFF
--- a/iron-autogrow-textarea.html
+++ b/iron-autogrow-textarea.html
@@ -137,6 +137,8 @@ Custom property | Description | Default
 
       /**
        * Use this property instead of `value` for two-way data binding.
+       * 
+       * @type {string|number}
        */
       bindValue: {
         observer: '_bindValueChanged',


### PR DESCRIPTION
Later on in the code we check to see if `this.bindValue === 0` which only makes sense if it can sometimes be a number