### PR TITLE
Simplify methods used to compute textarea size

### DIFF
--- a/iron-autogrow-textarea.html
+++ b/iron-autogrow-textarea.html
@@ -51,17 +51,7 @@ Custom property | Description | Default
       overflow: hidden;
     }
 
-    .mirror-text {
-      visibility: hidden;
-      word-wrap: break-word;
-    }
-
-    .fit {
-      @apply(--layout-fit);
-    }
-
     textarea {
-      position: relative;
       outline: none;
       border: none;
       resize: none;
@@ -69,7 +59,7 @@ Custom property | Description | Default
       color: inherit;
       /* see comments in template */
       width: 100%;
-      height: 100%;
+      height: auto;
       font-size: inherit;
       font-family: inherit;
       line-height: inherit;
@@ -80,32 +70,12 @@ Custom property | Description | Default
     ::content textarea:invalid {
       box-shadow: none;
     }
-
-    textarea::-webkit-input-placeholder {
-      @apply(--iron-autogrow-textarea-placeholder);
-    }
-
-    textarea:-moz-placeholder {
-      @apply(--iron-autogrow-textarea-placeholder);
-    }
-
-    textarea::-moz-placeholder {
-      @apply(--iron-autogrow-textarea-placeholder);
-    }
-
-    textarea:-ms-input-placeholder {
-      @apply(--iron-autogrow-textarea-placeholder);
-    }
   </style>
   <template>
-    <!-- the mirror sizes the input/textarea so it grows with typing -->
-    <!-- use &#160; instead &nbsp; of to allow this element to be used in XHTML -->
-    <div id="mirror" class="mirror-text" aria-hidden="true">&#160;</div>
-
     <!-- size the input/textarea with a div, because the textarea has intrinsic size in ff -->
-    <div class="textarea-container fit">
       <textarea id="textarea"
         name$="[[name]]"
+        value="{{value::input}}"
         autocomplete$="[[autocomplete]]"
         autofocus$="[[autofocus]]"
         inputmode$="[[inputmode]]"
@@ -115,7 +85,6 @@ Custom property | Description | Default
         disabled$="[[disabled]]"
         rows$="[[rows]]"
         maxlength$="[[maxlength]]"></textarea>
-    </div>
   </template>
 </dom-module>
 
@@ -134,13 +103,13 @@ Custom property | Description | Default
     properties: {
 
       /**
-       * Use this property instead of `value` for two-way data binding.
-       * This property will be deprecated in the future. Use `value` instead.
+       * Use this property for two-way data binding.
        * @type {string|number}
        */
-      bindValue: {
-        observer: '_bindValueChanged',
-        type: String
+      value: {
+        type: String,
+        notify: true,
+        observer: '_valueChanged'
       },
 
       /**
@@ -152,8 +121,7 @@ Custom property | Description | Default
        */
       rows: {
         type: Number,
-        value: 1,
-        observer: '_updateCached'
+        value: 1
       },
 
       /**
@@ -166,8 +134,7 @@ Custom property | Description | Default
        */
       maxRows: {
        type: Number,
-       value: 0,
-       observer: '_updateCached'
+       value: 0
       },
 
       /**
@@ -222,14 +189,6 @@ Custom property | Description | Default
       }
 
     },
-
-    listeners: {
-      'input': '_onInput'
-    },
-
-    observers: [
-      '_onValueChanged(value)'
-    ],
 
     /**
      * Returns the underlying textarea.
@@ -293,61 +252,19 @@ Custom property | Description | Default
       return valid;
     },
 
-    _bindValueChanged: function() {
+    _valueChanged: function() {
       var textarea = this.textarea;
       if (!textarea) {
         return;
       }
 
-      // If the bindValue changed manually, then we need to also update
-      // the underlying textarea's value. Otherwise this change was probably
-      // generated from the _onInput handler, and the two values are already
-      // the same.
-      if (textarea.value !== this.bindValue) {
-        textarea.value = !(this.bindValue || this.bindValue === 0) ? '' : this.bindValue;
+      // Update the underlying textarea height to `auto` thereby updating
+      // scrollHeight. If the texarea value is not empty an explicit height
+      // is applied to the textarea using scrollHeight.
+      textarea.style.height = 'auto';
+      if(textarea.value.length > 0) {
+        textarea.style.height = this.$.textarea.scrollHeight + 'px';
       }
-
-      this.value = this.bindValue;
-      this.$.mirror.innerHTML = this._valueForMirror();
-      // manually notify because we don't want to notify until after setting value
-      this.fire('bind-value-changed', {value: this.bindValue});
-    },
-
-    _onInput: function(event) {
-      this.bindValue = event.path ? event.path[0].value : event.target.value;
-    },
-
-    _constrain: function(tokens) {
-      var _tokens;
-      tokens = tokens || [''];
-      // Enforce the min and max heights for a multiline input to avoid measurement
-      if (this.maxRows > 0 && tokens.length > this.maxRows) {
-        _tokens = tokens.slice(0, this.maxRows);
-      } else {
-        _tokens = tokens.slice(0);
-      }
-      while (this.rows > 0 && _tokens.length < this.rows) {
-        _tokens.push('');
-      }
-      // Use &#160; instead &nbsp; of to allow this element to be used in XHTML.
-      return _tokens.join('<br/>') + '&#160;';
-    },
-
-    _valueForMirror: function() {
-      var input = this.textarea;
-      if (!input) {
-        return;
-      }
-      this.tokens = (input && input.value) ? input.value.replace(/&/gm, '&amp;').replace(/"/gm, '&quot;').replace(/'/gm, '&#39;').replace(/</gm, '&lt;').replace(/>/gm, '&gt;').split('\n') : [''];
-      return this._constrain(this.tokens);
-    },
-
-    _updateCached: function() {
-      this.$.mirror.innerHTML = this._constrain(this.tokens);
-    },
-
-    _onValueChanged: function() {
-      this.bindValue = this.value;
     }
   });
 </script>


### PR DESCRIPTION
Updates the underlying textarea height to `auto` thereby updating scrollHeight to a computed value upon change. If the texarea value is not empty, an explicit height is applied to the textarea using the computed scrollHeight. This commit also removes value mirroring and the depricated bindValue property.