### PR TITLE
2.0 preview

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-bower_components
+bower_components*
+bower-*.json

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ thing! https://github.com/PolymerLabs/tedium/issues
 _[Demo and API docs](https://elements.polymer-project.org/elements/iron-autogrow-textarea)_
 
 
-##&lt;iron-autogrow-textarea&gt;
+## &lt;iron-autogrow-textarea&gt;
 
 `iron-autogrow-textarea` is an element containing a textarea that grows in height as more
 lines of input are entered. Unless an explicit height or the `maxRows` property is set, it will
@@ -28,6 +28,10 @@ Example:
 ```html
 <iron-autogrow-textarea></iron-autogrow-textarea>
 ```
+
+### Changes in 2.0
+- `bind-value` is deprecated, and just mirrors the `value` property 
+- corrected the behaviour of `validate()`
 
 ### Styling
 

--- a/bower.json
+++ b/bower.json
@@ -27,6 +27,7 @@
     "polymer": "Polymer/polymer#^2.0.0-rc.1"
   },
   "devDependencies": {
+    "iron-component-page": "PolymerElements/iron-component-page#2.0-preview",
     "iron-demo-helpers": "PolymerElements/iron-demo-helpers#2.0-preview",
     "iron-test-helpers": "PolymerElements/iron-test-helpers#2.0-preview",
     "paper-styles": "PolymerElements/paper-styles#2.0-preview",
@@ -43,6 +44,7 @@
         "polymer": "Polymer/polymer#^1.1.0"
       },
       "devDependencies": {
+        "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
         "iron-demo-helpers": "PolymerElements/iron-demo-helpers#^1.0.0",
         "iron-test-helpers": "PolymerElements/iron-test-helpers#^1.0.0",
         "paper-styles": "PolymerElements/paper-styles#^1.0.0",

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "iron-autogrow-textarea",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "description": "A textarea element that automatically grows with input",
   "authors": [
     "The Polymer Authors"

--- a/bower.json
+++ b/bower.json
@@ -24,7 +24,7 @@
     "iron-behaviors": "PolymerElements/iron-behaviors#2.0-preview",
     "iron-flex-layout": "PolymerElements/iron-flex-layout#2.0-preview",
     "iron-validatable-behavior": "PolymerElements/iron-validatable-behavior#2.0-preview",
-    "polymer": "Polymer/polymer#2.0-preview"
+    "polymer": "Polymer/polymer#^2.0.0-rc.1"
   },
   "devDependencies": {
     "iron-demo-helpers": "PolymerElements/iron-demo-helpers#2.0-preview",

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "iron-autogrow-textarea",
-  "version": "1.0.13",
+  "version": "2.0.0",
   "description": "A textarea element that automatically grows with input",
   "authors": [
     "The Polymer Authors"
@@ -21,19 +21,20 @@
   "homepage": "https://github.com/PolymerElements/iron-autogrow-textarea",
   "ignore": [],
   "dependencies": {
-    "iron-behaviors": "PolymerElements/iron-behaviors#^1.0.0",
-    "iron-flex-layout": "PolymerElements/iron-flex-layout#^1.0.0",
-    "iron-validatable-behavior": "PolymerElements/iron-validatable-behavior#^1.0.0",
-    "iron-form-element-behavior": "PolymerElements/iron-form-element-behavior#^1.0.0",
-    "polymer": "Polymer/polymer#^1.1.0"
+    "iron-behaviors": "PolymerElements/iron-behaviors#2.0-preview",
+    "iron-flex-layout": "PolymerElements/iron-flex-layout#2.0-preview",
+    "iron-validatable-behavior": "PolymerElements/iron-validatable-behavior#2.0-preview",
+    "polymer": "Polymer/polymer#2.0-preview"
   },
   "devDependencies": {
-    "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
-    "iron-demo-helpers": "PolymerElements/iron-demo-helpers#^1.0.0",
-    "iron-test-helpers": "PolymerElements/iron-test-helpers#^1.0.0",
-    "test-fixture": "PolymerElements/test-fixture#^1.0.0",
+    "iron-demo-helpers": "PolymerElements/iron-demo-helpers#2.0-preview",
+    "iron-test-helpers": "PolymerElements/iron-test-helpers#2.0-preview",
+    "paper-styles": "PolymerElements/paper-styles#2.0-preview",
+    "test-fixture": "PolymerElements/test-fixture#custom-elements-v1",
     "web-component-tester": "^4.0.0",
-    "paper-styles": "PolymerElements/paper-styles#^1.0.0",
-    "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0"
+    "webcomponentsjs": "webcomponents/webcomponentsjs#v1"
+  },
+  "resolutions": {
+    "test-fixture": "custom-elements-v1"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -30,12 +30,9 @@
     "iron-demo-helpers": "PolymerElements/iron-demo-helpers#2.0-preview",
     "iron-test-helpers": "PolymerElements/iron-test-helpers#2.0-preview",
     "paper-styles": "PolymerElements/paper-styles#2.0-preview",
-    "test-fixture": "PolymerElements/test-fixture#^2.0.0",
-    "web-component-tester": "v6.0.0-prerelease.5",
-    "webcomponentsjs": "webcomponents/webcomponentsjs#v1"
-  },
-  "resolutions": {
-    "test-fixture": "^2.0.0"
+    "test-fixture": "PolymerElements/test-fixture#^3.0.0-rc.1",
+    "web-component-tester": "Polymer/web-component-tester#^6.0.0-prerelease.6",
+    "webcomponentsjs": "webcomponents/webcomponentsjs#^1.0.0-rc.1"
   },
   "variants": {
     "1.x": {
@@ -50,7 +47,8 @@
         "iron-test-helpers": "PolymerElements/iron-test-helpers#^1.0.0",
         "paper-styles": "PolymerElements/paper-styles#^1.0.0",
         "test-fixture": "PolymerElements/test-fixture#^1.0.0",
-        "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0"
+        "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0",
+        "web-component-tester": "Polymer/web-component-tester#^4.0.0"
       }
     }
   }

--- a/demo/index.html
+++ b/demo/index.html
@@ -21,7 +21,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <link rel="import" href="../../iron-demo-helpers/demo-snippet.html">
     <link rel="import" href="../../iron-demo-helpers/demo-pages-shared-styles.html">
-    <link rel="import" href="../../paper-styles/shadow.html">
     <link rel="import" href="../iron-autogrow-textarea.html">
 
     <custom-style>
@@ -88,7 +87,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
                 <br>
                 <p>Imperatively updating <code>ironAutogrowTextarea.textarea.value</code> will update
-                the display, but not update the internal<code>value</code></p>
+                the display, but not update the internal <code>value</code></p>
                 <button onclick="a1.textarea.value='watermelon'">Set textarea.value to 'watermelon'</button>
               </div>
             </template>

--- a/demo/index.html
+++ b/demo/index.html
@@ -78,17 +78,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           <dom-bind>
             <template is="dom-bind">
               <div class="vertical-section">
-                <iron-autogrow-textarea bind-value="{{bindValue}}" id="a1"></iron-autogrow-textarea>
-                <p>bind to the iron-autogrow-textarea's <code>bind-value</code>: {{bindValue}}</p>
+                <iron-autogrow-textarea value="{{value}}" id="a1"></iron-autogrow-textarea>
+                <p>bind to the iron-autogrow-textarea's <code>value</code>: {{value}}</p>
 
                 <br>
-                <p>Imperatively updating <code>ironAutogrowTextarea.bindValue</code> will also update the
+                <p>Imperatively updating <code>ironAutogrowTextarea.value</code> will also update the
                 <code>textarea.value</code></p>
-                <button onclick="a1.bindValue='pineapple'">Set bindValue to 'pineapple'</button>
+                <button onclick="a1.value='pineapple'">Set value to 'pineapple'</button>
 
                 <br>
                 <p>Imperatively updating <code>ironAutogrowTextarea.textarea.value</code> will update
-                the display, but not update the internal<code>bind-value</code></p>
+                the display, but not update the internal<code>value</code></p>
                 <button onclick="a1.textarea.value='watermelon'">Set textarea.value to 'watermelon'</button>
               </div>
             </template>

--- a/demo/index.html
+++ b/demo/index.html
@@ -18,32 +18,37 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <title>iron-autogrow-textarea demo</title>
 
     <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+
     <link rel="import" href="../../iron-demo-helpers/demo-snippet.html">
     <link rel="import" href="../../iron-demo-helpers/demo-pages-shared-styles.html">
+    <link rel="import" href="../../paper-styles/shadow.html">
     <link rel="import" href="../iron-autogrow-textarea.html">
 
-    <style is="custom-style" include="demo-pages-shared-styles">
-      iron-autogrow-textarea {
-        display: block;
-        width: 200px;
-        margin: 5px 0;
-      }
+    <custom-style>
+      <style is="custom-style" include="demo-pages-shared-styles">
+        iron-autogrow-textarea {
+          display: block;
+          width: 200px;
+          margin: 5px 0;
+        }
 
-      textarea {
-        width: 200px;
-      }
+        textarea {
+          width: 200px;
+        }
 
-      .vertical-section {
-        box-sizing: border-box;
-        width: 400px;
-        margin: 0;
-      }
-    </style>
+        demo-snippet {
+          --demo-snippet-demo: {
+            @apply --layout-vertical;
+            @apply --layout-center-center;
+          }
+        }
+      </style>
+    </custom-style>
   </head>
   <body unresolved>
     <div class="vertical-section-container centered">
       <h3>An iron-autogrow-textarea grows automatically as more text is entered</h3>
-      <demo-snippet class="centered-demo">
+      <demo-snippet>
         <template>
           <iron-autogrow-textarea></iron-autogrow-textarea>
         </template>
@@ -51,7 +56,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       <h3>The maximum height can be controlled either through the <i>max-rows</i>
       property, or through a fixed max height</h3>
-      <demo-snippet class="centered-demo">
+      <demo-snippet>
         <template>
           <iron-autogrow-textarea max-rows="4" placeholder="scrolls after 4 rows"></iron-autogrow-textarea>
           <iron-autogrow-textarea style="max-height: 50px;" placeholder="scrolls after 50px"></iron-autogrow-textarea>
@@ -60,7 +65,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       <h3>The initial height can also be controlled using the <i>rows</i> property,
       or through a fixed height</h3>
-      <demo-snippet class="centered-demo">
+      <demo-snippet>
         <template>
           <iron-autogrow-textarea rows="4" placeholder="start with 4 rows"></iron-autogrow-textarea>
           <iron-autogrow-textarea style="height: 50px;"></iron-autogrow-textarea>
@@ -68,44 +73,28 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       </demo-snippet>
 
       <h3>Example of updating the value imperatively</h3>
-      <!-- TODO: replace this with a demo-snippet when https://github.com/webcomponents/webcomponentsjs/issues/362
-      is fixed -->
-      <div class="example">
-        <template is="dom-bind">
-          <div class="vertical-section">
-            <iron-autogrow-textarea bind-value="{{bindValue}}" id="a1"></iron-autogrow-textarea>
-            <br>
-            <code>bind-value</code>: <span>[[bindValue]]</span>
-            <p on-click="setValue">
-              Imperatively changing <code>bind-value</code> will also update
-              <code>textarea.value</code>:<br>
-              <textarea></textarea>
-              <button value="bindValue">set</button>
-              <br><br>
+      <demo-snippet>
+        <template>
+          <dom-bind>
+            <template is="dom-bind">
+              <div class="vertical-section">
+                <iron-autogrow-textarea bind-value="{{bindValue}}" id="a1"></iron-autogrow-textarea>
+                <p>bind to the iron-autogrow-textarea's <code>bind-value</code>: {{bindValue}}</p>
 
-              Imperatively updating <code>textarea.value</code> will update
-              the display, but not update <code>bind-value</code>:<br>
-              <textarea></textarea>
-              <button value="value">set</button>
-            </p>
-          </div>
+                <br>
+                <p>Imperatively updating <code>ironAutogrowTextarea.bindValue</code> will also update the
+                <code>textarea.value</code></p>
+                <button onclick="a1.bindValue='pineapple'">Set bindValue to 'pineapple'</button>
+
+                <br>
+                <p>Imperatively updating <code>ironAutogrowTextarea.textarea.value</code> will update
+                the display, but not update the internal<code>bind-value</code></p>
+                <button onclick="a1.textarea.value='watermelon'">Set textarea.value to 'watermelon'</button>
+              </div>
+            </template>
+          </dom-bind>
         </template>
-      </div>
+      </demo-snippet>
     </div>
-    <script>
-      var scope = document.querySelector('template[is=dom-bind]');
-
-      scope.setValue = function(event) {
-        if (!(event.target instanceof HTMLButtonElement)) {
-          return;
-        }
-        var inputValue = event.target.previousElementSibling.value;
-        if (event.target.value == "bindValue") {
-          document.querySelector('#a1').bindValue = inputValue;
-        } else {
-          document.querySelector('#a1').textarea.value = inputValue;
-        }
-      }
-    </script>
   </body>
 </html>

--- a/iron-autogrow-textarea.html
+++ b/iron-autogrow-textarea.html
@@ -76,24 +76,20 @@ Custom property | Description | Default
         @apply --iron-autogrow-textarea;
       }
 
-      ::content textarea:invalid {
-        box-shadow: none;
-      }
-
       textarea::-webkit-input-placeholder {
-        @apply(--iron-autogrow-textarea-placeholder);
+        @apply --iron-autogrow-textarea-placeholder;
       }
 
       textarea:-moz-placeholder {
-        @apply(--iron-autogrow-textarea-placeholder);
+        @apply --iron-autogrow-textarea-placeholder;
       }
 
       textarea::-moz-placeholder {
-        @apply(--iron-autogrow-textarea-placeholder);
+        @apply --iron-autogrow-textarea-placeholder;
       }
 
       textarea:-ms-input-placeholder {
-        @apply(--iron-autogrow-textarea-placeholder);
+        @apply --iron-autogrow-textarea-placeholder;
       }
     </style>
 

--- a/iron-autogrow-textarea.html
+++ b/iron-autogrow-textarea.html
@@ -132,7 +132,7 @@ Custom property | Description | Default
 
     properties: {
       /**
-       * Use this property instead of `value` for two-way data binding.
+       * Use this property instead of `bind-value` for two-way data binding.
        * @type {string|number}
        */
       value: {

--- a/iron-autogrow-textarea.html
+++ b/iron-autogrow-textarea.html
@@ -345,7 +345,8 @@ Custom property | Description | Default
     },
 
     _onInput: function(event) {
-      this.value = event.path ? event.path[0].value : event.target.value;
+      var eventPath = Polymer.dom(event).path;
+      this.value = eventPath ? eventPath[0].value : event.target.value;
     },
 
     _constrain: function(tokens) {

--- a/iron-autogrow-textarea.html
+++ b/iron-autogrow-textarea.html
@@ -234,10 +234,6 @@ Custom property | Description | Default
       'input': '_onInput'
     },
 
-    observers: [
-      '_onValueChanged(value)'
-    ],
-
     /**
      * Returns the underlying textarea.
      * @type HTMLTextAreaElement
@@ -289,10 +285,10 @@ Custom property | Description | Default
       // Only do extra checking if the browser thought this was valid.
       if (valid) {
         // Empty, required input is invalid
-        if (this.required && this.bindValue === '') {
+        if (this.required && this.value === '') {
           valid = false;
         } else if (this.hasValidator()) {
-          valid = Polymer.IronValidatableBehavior.validate.call(this, this.bindValue);
+          valid = Polymer.IronValidatableBehavior.validate.call(this, this.value);
         }
       }
 
@@ -301,11 +297,11 @@ Custom property | Description | Default
       return valid;
     },
 
-    _bindValueChanged: function(value) {
+    _bindValueChanged: function(bindValue) {
       this.value = bindValue;
     },
 
-    _bindValueChanged: function(bindValue) {
+    _valueChanged: function(value) {
       var textarea = this.textarea;
       if (!textarea) {
         return;
@@ -315,11 +311,11 @@ Custom property | Description | Default
       // the underlying textarea's value. Otherwise this change was probably
       // generated from the _onInput handler, and the two values are already
       // the same.
-      if (textarea.value !== bindValue) {
-        textarea.value = !(bindValue || bindValue === 0) ? '' : bindValue;
+      if (textarea.value !== value) {
+        textarea.value = !(value || value === 0) ? '' : value;
       }
 
-      this.value = bindValue;
+      this.bindValue = value;
       this.$.mirror.innerHTML = this._valueForMirror();
 
       // This code is from early 1.0, when this element was a type extension.
@@ -329,7 +325,7 @@ Custom property | Description | Default
     },
 
     _onInput: function(event) {
-      this.bindValue = event.path ? event.path[0].value : event.target.value;
+      this.value = event.path ? event.path[0].value : event.target.value;
     },
 
     _constrain: function(tokens) {

--- a/iron-autogrow-textarea.html
+++ b/iron-autogrow-textarea.html
@@ -12,7 +12,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../iron-behaviors/iron-control-state.html">
 <link rel="import" href="../iron-flex-layout/iron-flex-layout.html">
 <link rel="import" href="../iron-validatable-behavior/iron-validatable-behavior.html">
-<link rel="import" href="../iron-form-element-behavior/iron-form-element-behavior.html">
 
 <!--
 `iron-autogrow-textarea` is an element containing a textarea that grows in height as more
@@ -57,7 +56,7 @@ Custom property | Description | Default
       }
 
       .fit {
-        @apply(--layout-fit);
+        @apply --layout-fit;
       }
 
       textarea {
@@ -74,7 +73,7 @@ Custom property | Description | Default
         font-family: inherit;
         line-height: inherit;
         text-align: inherit;
-        @apply(--iron-autogrow-textarea);
+        @apply --iron-autogrow-textarea;
       }
 
       ::content textarea:invalid {
@@ -126,21 +125,29 @@ Custom property | Description | Default
     is: 'iron-autogrow-textarea',
 
     behaviors: [
-      Polymer.IronFormElementBehavior,
       Polymer.IronValidatableBehavior,
       Polymer.IronControlState
     ],
 
     properties: {
-
       /**
        * Use this property instead of `value` for two-way data binding.
-       * This property will be deprecated in the future. Use `value` instead.
+       * @type {string|number}
+       */
+      value: {
+        observer: '_valueChanged',
+        type: String,
+        notify: true
+      },
+
+      /**
+       * This property is deprecated, and just mirrors `value`. Use `value` instead.
        * @type {string|number}
        */
       bindValue: {
         observer: '_bindValueChanged',
-        type: String
+        type: String,
+        notify: true
       },
 
       /**
@@ -276,24 +283,29 @@ Custom property | Description | Default
      * @return {boolean} True if the value is valid.
      */
     validate: function() {
-      // Empty, non-required input is valid.
-      if (!this.required && this.value == '') {
-        this.invalid = false;
-        return true;
+      // Use the nested input's native validity.
+      var valid =  this.$.textarea.validity.valid;
+
+      // Only do extra checking if the browser thought this was valid.
+      if (valid) {
+        // Empty, required input is invalid
+        if (this.required && this.bindValue === '') {
+          valid = false;
+        } else if (this.hasValidator()) {
+          valid = Polymer.IronValidatableBehavior.validate.call(this, this.bindValue);
+        }
       }
 
-      var valid;
-      if (this.hasValidator()) {
-        valid = Polymer.IronValidatableBehavior.validate.call(this, this.value);
-      } else {
-        valid = this.$.textarea.validity.valid;
-        this.invalid = !valid;
-      }
+      this.invalid = !valid;
       this.fire('iron-input-validate');
       return valid;
     },
 
-    _bindValueChanged: function() {
+    _bindValueChanged: function(value) {
+      this.value = bindValue;
+    },
+
+    _bindValueChanged: function(bindValue) {
       var textarea = this.textarea;
       if (!textarea) {
         return;
@@ -303,14 +315,17 @@ Custom property | Description | Default
       // the underlying textarea's value. Otherwise this change was probably
       // generated from the _onInput handler, and the two values are already
       // the same.
-      if (textarea.value !== this.bindValue) {
-        textarea.value = !(this.bindValue || this.bindValue === 0) ? '' : this.bindValue;
+      if (textarea.value !== bindValue) {
+        textarea.value = !(bindValue || bindValue === 0) ? '' : bindValue;
       }
 
-      this.value = this.bindValue;
+      this.value = bindValue;
       this.$.mirror.innerHTML = this._valueForMirror();
-      // manually notify because we don't want to notify until after setting value
-      this.fire('bind-value-changed', {value: this.bindValue});
+
+      // This code is from early 1.0, when this element was a type extension.
+      // It's unclear if it's still needed, but leaving in in case it is.
+      // manually notify because we don't want to notify until after setting value.
+      // this.fire('bind-value-changed', {value: this.bindValue});
     },
 
     _onInput: function(event) {
@@ -345,9 +360,5 @@ Custom property | Description | Default
     _updateCached: function() {
       this.$.mirror.innerHTML = this._constrain(this.tokens);
     },
-
-    _onValueChanged: function() {
-      this.bindValue = this.value;
-    }
   });
 </script>

--- a/test/index.html
+++ b/test/index.html
@@ -15,7 +15,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <body>
     <script>
       WCT.loadSuites([
-        'basic.html?wc-shadydom=true&wc-register=true',
+        'basic.html?wc-shadydom=true&wc-ce=true',
         'basic.html?dom=shadow'
       ]);
     </script>

--- a/test/index.html
+++ b/test/index.html
@@ -15,10 +15,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <body>
     <script>
       WCT.loadSuites([
-        'basic.html',
+        'basic.html?wc-shadydom=true&wc-register=true',
         'basic.html?dom=shadow'
       ]);
     </script>
-  
+
 
 </body></html>


### PR DESCRIPTION
Notable changes:
- `bindValue` was marked as deprecated, said to use `value` instead, but `value` wasn't defined and `bindValue` was still doing all the heavy lifting. Also, in 2.0 if you don't declare a property you don't serialize to it either, so anyway, cleaned this up.
- made `value`/`bindValue` be a notifying property vs fire the `foo-changed` event manually. It's currently broken in 2.0 and I'm not 100% sure if we need it anymore, since the long-ago days when `iron-autogrow-textarea` stopped being a type extension.
- cleaned up the `validate` code to match that of `iron-input`, and have the correct behaviour of using the native validity first. I think that's correct and not a giant breaking change
