### PR TITLE
Fix weird iOS margin-left 

### DIFF
--- a/iron-autogrow-textarea.html
+++ b/iron-autogrow-textarea.html
@@ -77,6 +77,39 @@ Custom property | Description | Default
         @apply(--iron-autogrow-textarea);
       }
 
+      /* iOS has an arbitrary left margin of 3px that isn't present
+       * in any other browser, and means that the paper-textarea's cursor
+       * overlaps the label.
+       * See https://github.com/PolymerElements/paper-input/issues/468 */
+      textarea {
+        margin-left: -3px;
+      }
+
+      /* Undo the margin on non-iOS, non-Edge, non-IE (=.=). This hack is taken from
+       * http://browserstrangeness.bitbucket.org/css_hacks.html#webkit
+       * and I'm sure one day will end, but for now, here we are.
+       */
+      _:-webkit-full-screen-ancestor, :host textarea {
+        margin-left: 0px;
+      }
+
+      /* Undo on Edge */
+      _:-ms-lang(x), _:-webkit-full-screen, textarea {
+        margin-left: 0px;
+      }
+
+      /* Undo on IE. Safari, this is why we can't have nice things. */
+      _:-ms-fullscreen, :root textarea {
+        margin-left: 0px;
+      }
+
+      /* Undo on FF */
+      @-moz-document url-prefix() {
+        textarea {
+          margin-left: 0px;
+        }
+      }
+
       ::content textarea:invalid {
         box-shadow: none;
       }


### PR DESCRIPTION
Fixes https://github.com/PolymerElements/paper-input/issues/468
TL;DR: iOS has a rando 3px margin-left that no other browser has, which means, say, if you're trying to position the `paper-textarea`'s label in a sane place, the cursor is going to overlap it and you're going to have a bad time. 

Before this PR:
<img width="453" alt="screen shot 2017-01-05 at 3 02 43" src="https://cloud.githubusercontent.com/assets/1369170/21700997/21e4979e-d358-11e6-912c-b105531a6f1a.png">

After this PR:
<img width="453" alt="screen shot 2017-01-05 at 3 03 01" src="https://cloud.githubusercontent.com/assets/1369170/21700999/23b2265e-d358-11e6-81cd-a482d3910b2f.png">

For the record, that's what that input looks like on Chrome and even desktop Safari (i.e. doesn't have the padding):
Chrome:
<img width="453" alt="screen shot 2017-01-05 at 3 05 13" src="https://cloud.githubusercontent.com/assets/1369170/21701079/7b78684e-d358-11e6-8492-015c57ae5a58.png">

Safari:
<img width="447" alt="screen shot 2017-01-05 at 3 05 26" src="https://cloud.githubusercontent.com/assets/1369170/21701082/7dff8ae8-d358-11e6-9f3c-d548a967e98c.png">

