### PR TITLE
Fix non-standard iOS-only margin-left

### DIFF
--- a/iron-autogrow-textarea.html
+++ b/iron-autogrow-textarea.html
@@ -277,6 +277,18 @@ Custom property | Description | Default
       this.$.textarea.selectionEnd = value;
     },
 
+    attached: function() {
+      /* iOS has an arbitrary left margin of 3px that isn't present
+       * in any other browser, and means that the paper-textarea's cursor
+       * overlaps the label.
+       * See https://github.com/PolymerElements/paper-input/issues/468.
+       */
+      var IS_IOS = navigator.userAgent.match(/iP(?:[oa]d|hone)/);
+      if (IS_IOS) {
+        this.$.textarea.style.marginLeft = '-3px';
+      }
+    },
+
     /**
      * Returns true if `value` is valid. The validator provided in `validator`
      * will be used first, if it exists; otherwise, the `textarea`'s validity


### PR DESCRIPTION
Fixes https://github.com/PolymerElements/paper-input/issues/468

TL;DR: iOS has a rando 3px margin-left that no other browser has, which means, say, if you're trying to position the `paper-textarea`'s label in a sane place, the cursor is going to overlap it and you're going to have a bad time.

Before this PR:
![screen shot 2017-01-05 at 3 50 09](https://cloud.githubusercontent.com/assets/1369170/21702193/151983ec-d35f-11e6-9a8e-f8541c3c929a.png)

After this PR:
![screen shot 2017-01-05 at 3 49 53](https://cloud.githubusercontent.com/assets/1369170/21702197/17d16abe-d35f-11e6-99be-ff3ea6e3e52a.png)

(the after now matches what we saw in Chrome/Safari/FF normally, which stays unchanged)