### PR TITLE
Added aria label to element

### DIFF
--- a/iron-autogrow-textarea.html
+++ b/iron-autogrow-textarea.html
@@ -104,7 +104,9 @@ Custom property | Description | Default
 
     <!-- size the input/textarea with a div, because the textarea has intrinsic size in ff -->
     <div class="textarea-container fit">
+      <label id$="textarea-aria-label-[[_ariaLabelId]]">[[label]]</label>
       <textarea id="textarea"
+        aria-labelledby$="textarea-aria-label-[[_ariaLabelId]]"
         name$="[[name]]"
         autocomplete$="[[autocomplete]]"
         autofocus$="[[autofocus]]"
@@ -227,8 +229,22 @@ Custom property | Description | Default
        */
       maxlength: {
         type: Number
-      }
+      },
 
+      /**
+       * Aria label to present to screen readers.
+       */
+      label: {
+        type: String
+      },
+
+      /**
+       * Aria label id used to get a unique id for element
+       */
+      _ariaLabelId: {
+        type: Number,
+        value: Polymer.PaperInputHelper.NextLabelID++
+      }
     },
 
     listeners: {


### PR DESCRIPTION
Added aria label to the element so it is in the same shadow DOM and read by screen readers.

I wondered why I wasn't able to get the screen reader to read the label of my input-textarea and it seems to be because of encapsulation between components.

Tested on Chrome with NVDA screen reader.