### PR TITLE
Fixes value / bind-value not working in 2.0-preview on Firefox / Edge

### DIFF
--- a/iron-autogrow-textarea.html
+++ b/iron-autogrow-textarea.html
@@ -104,6 +104,7 @@ Custom property | Description | Default
     <!-- size the input/textarea with a div, because the textarea has intrinsic size in ff -->
     <div class="textarea-container fit">
       <textarea id="textarea"
+        on-input="_onInput"
         name$="[[name]]"
         autocomplete$="[[autocomplete]]"
         autofocus$="[[autofocus]]"
@@ -236,10 +237,6 @@ Custom property | Description | Default
         type: Number
       }
 
-    },
-
-    listeners: {
-      'input': '_onInput'
     },
 
     /**


### PR DESCRIPTION
Makes sure that the correct event target value is delivered to _onInput.
This fixes #100.