### PR TITLE
re-enable `bind-value-changed` event

### DIFF
--- a/iron-autogrow-textarea.html
+++ b/iron-autogrow-textarea.html
@@ -334,10 +334,8 @@ Custom property | Description | Default
       this.bindValue = value;
       this.$.mirror.innerHTML = this._valueForMirror();
 
-      // This code is from early 1.0, when this element was a type extension.
-      // It's unclear if it's still needed, but leaving in in case it is.
-      // manually notify because we don't want to notify until after setting value.
-      // this.fire('bind-value-changed', {value: this.bindValue});
+      // Manually notify because we don't want to notify until after setting value.
+      this.fire('bind-value-changed', {value: this.bindValue});
     },
 
     _onInput: function(event) {


### PR DESCRIPTION
This is still needed in paper-input/paper-input-container.html (L513 of paper-input-v2.0.1)

Fixes PolymerElements/paper-input#508

The event listened to is "hidden" behind `_valueChangedEvent`, which returns `bind-value-changed` by default ([GitHub link](/PolymerElements/paper-input/blob/v2.0.1/paper-input-container.html#L513))
