### PR TITLE
Add mixin properties to mirror

### DIFF
--- a/iron-autogrow-textarea.html
+++ b/iron-autogrow-textarea.html
@@ -53,6 +53,7 @@ Custom property | Description | Default
       .mirror-text {
         visibility: hidden;
         word-wrap: break-word;
+        @apply --iron-autogrow-textarea;
       }
 
       .fit {


### PR DESCRIPTION
When different styles are added to the textarea (ex: white-space: pre),
the mirror no longer accurately represents the height of the textarea.

In order to fix this, apply the mixin  styles applied to the textarea
to the mirror also.