### PR TITLE
Add missing name propertie cought by polylint

### DIFF
--- a/iron-autogrow-textarea.html
+++ b/iron-autogrow-textarea.html
@@ -239,6 +239,13 @@ Custom property | Description | Default
        */
       label: {
         type: String
+      },
+
+      /**
+       * Bound to the textarea's `name` attribute.
+       */
+      name: {
+        type: String
       }
 
     },


### PR DESCRIPTION
https://gerrit-ci.gerritforge.com/job/Gerrit-codestyle/2092/console

warn:    bower_components/iron-autogrow-textarea/iron-autogrow-textarea.html:103:7
    Property 'name' bound to attribute 'name$' not found in 'properties' for element 'iron-autogrow-textarea'
================================================================================
Target //polygerrit-ui/app:polylint_test up-to-date:
  bazel-bin/polygerrit-ui/app/polylint_test
____Elapsed time: 31.465s, Critical Path: 23.73s
//polygerrit-ui/app:polylint_test                                        FAILED in 22.6s
  /home/jenkins/.cache/bazel/_bazel_jenkins/1678ab5d651d6116cf0d320f4af2a3c9/execroot/gerrit/bazel-out/local-fastbuild/testlogs/polygerrit-ui/app/polylint_test/test.log