### PR TITLE
fix: on-change event in shadowRoot

### DIFF
--- a/iron-autogrow-textarea.d.ts
+++ b/iron-autogrow-textarea.d.ts
@@ -31,7 +31,7 @@
  * `--iron-autogrow-textarea` | Mixin applied to the textarea | `{}`
  * `--iron-autogrow-textarea-placeholder` | Mixin applied to the textarea placeholder | `{}`
  */
-interface IronAutogrowTextareaElement extends Polymer.IronValidatableBehavior, Polymer.IronControlState, Polymer.LegacyElementMixin, HTMLElement {
+interface IronAutogrowTextareaElement extends Polymer.Element, Polymer.IronValidatableBehavior, Polymer.IronControlState {
 
   /**
    * Use this property instead of `bind-value` for two-way data binding.

--- a/iron-autogrow-textarea.d.ts
+++ b/iron-autogrow-textarea.d.ts
@@ -31,7 +31,7 @@
  * `--iron-autogrow-textarea` | Mixin applied to the textarea | `{}`
  * `--iron-autogrow-textarea-placeholder` | Mixin applied to the textarea placeholder | `{}`
  */
-interface IronAutogrowTextareaElement extends Polymer.Element, Polymer.IronValidatableBehavior, Polymer.IronControlState {
+interface IronAutogrowTextareaElement extends Polymer.IronValidatableBehavior, Polymer.IronControlState, Polymer.LegacyElementMixin, HTMLElement {
 
   /**
    * Use this property instead of `bind-value` for two-way data binding.
@@ -130,6 +130,7 @@ interface IronAutogrowTextareaElement extends Polymer.Element, Polymer.IronValid
   _constrain(tokens: any): any;
   _valueForMirror(): any;
   _updateCached(): void;
+  _onChange(event: any): void;
 }
 
 interface HTMLElementTagNameMap {

--- a/iron-autogrow-textarea.html
+++ b/iron-autogrow-textarea.html
@@ -112,7 +112,8 @@ Custom property | Description | Default
         disabled$="[[disabled]]"
         rows$="[[rows]]"
         minlength$="[[minlength]]"
-        maxlength$="[[maxlength]]"></textarea>
+        maxlength$="[[maxlength]]"
+        on-change="_onChange"></textarea>
     </div>
   </template>
 </dom-module>
@@ -346,6 +347,19 @@ Custom property | Description | Default
 
     _updateCached: function() {
       this.$.mirror.innerHTML = this._constrain(this.tokens);
+    },
+      
+    _onChange: function(event) {
+      // In the Shadow DOM, the `change` event is not leaked into the
+      // ancestor tree, so we must do this manually.
+      // See https://w3c.github.io/webcomponents/spec/shadow/#events-that-are-not-leaked-into-ancestor-trees.
+      if (this.shadowRoot) {
+        this.fire(event.type, {sourceEvent: event}, {
+          node: this,
+          bubbles: event.bubbles,
+          cancelable: event.cancelable
+        });
+      }
     },
   });
 </script>

--- a/iron-autogrow-textarea.html
+++ b/iron-autogrow-textarea.html
@@ -348,17 +348,17 @@ Custom property | Description | Default
     _updateCached: function() {
       this.$.mirror.innerHTML = this._constrain(this.tokens);
     },
-      
+
     _onChange: function(event) {
       // In the Shadow DOM, the `change` event is not leaked into the
       // ancestor tree, so we must do this manually.
-      // See https://w3c.github.io/webcomponents/spec/shadow/#events-that-are-not-leaked-into-ancestor-trees.
+      // See
+      // https://w3c.github.io/webcomponents/spec/shadow/#events-that-are-not-leaked-into-ancestor-trees.
       if (this.shadowRoot) {
-        this.fire(event.type, {sourceEvent: event}, {
-          node: this,
-          bubbles: event.bubbles,
-          cancelable: event.cancelable
-        });
+        this.fire(
+            event.type,
+            {sourceEvent: event},
+            {node: this, bubbles: event.bubbles, cancelable: event.cancelable});
       }
     },
   });


### PR DESCRIPTION
As you know, In the Shadow DOM, the `change` event is not leaked into the ancestor tree, so we must do this manually.
This is done in the rest of the input components by `paper-input-behavior`.

Fixed https://github.com/PolymerElements/paper-input/issues/664