### PR TITLE
Add missing autocapitalize attribute

### DIFF
--- a/iron-autogrow-textarea.js
+++ b/iron-autogrow-textarea.js
@@ -103,7 +103,7 @@ Polymer({
 
     <!-- size the input/textarea with a div, because the textarea has intrinsic size in ff -->
     <div class="textarea-container fit">
-      <textarea id="textarea" name\$="[[name]]" aria-label\$="[[label]]" autocomplete\$="[[autocomplete]]" autofocus\$="[[autofocus]]" inputmode\$="[[inputmode]]" placeholder\$="[[placeholder]]" readonly\$="[[readonly]]" required\$="[[required]]" disabled\$="[[disabled]]" rows\$="[[rows]]" minlength\$="[[minlength]]" maxlength\$="[[maxlength]]"></textarea>
+      <textarea id="textarea" name\$="[[name]]" aria-label\$="[[label]]" autocomplete\$="[[autocomplete]]" autofocus\$="[[autofocus]]" autocapitalize\$="[[autocapitalize]]" inputmode\$="[[inputmode]]" placeholder\$="[[placeholder]]" readonly\$="[[readonly]]" required\$="[[required]]" disabled\$="[[disabled]]" rows\$="[[rows]]" minlength\$="[[minlength]]" maxlength\$="[[maxlength]]"></textarea>
     </div>
 `,
 

--- a/iron-autogrow-textarea.js
+++ b/iron-autogrow-textarea.js
@@ -154,6 +154,11 @@ Polymer({
     autofocus: {type: Boolean, value: false},
 
     /**
+     * Bound to the textarea's `autocomplete` attribute.
+     */
+    autocapitalize: {type: String, value: 'none'},
+
+    /**
      * Bound to the textarea's `inputmode` attribute.
      */
     inputmode: {type: String},


### PR DESCRIPTION
## Description

The `textarea` does not support `autocapitalize`.

This adds this attribute as per the spec:

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#Attributes