### PR TITLE
fix paper-input #531

### DIFF
--- a/iron-autogrow-textarea.html
+++ b/iron-autogrow-textarea.html
@@ -264,7 +264,9 @@ Custom property | Description | Default
      */
     validate: function() {
       // Use the nested input's native validity.
-      var valid = this.$.textarea.validity.valid;
+      // Note(cg): validate happens too early when `paper-texarea` has an initial value 
+      // and is `auto-validate` (this.$ is undefined - https://github.com/PolymerElements/paper-input/issues/531)
+      var valid = this.$ ? this.$.textarea.validity.valid : true;
 
       // Only do extra checking if the browser thought this was valid.
       if (valid) {


### PR DESCRIPTION
Fixes (reported in https://github.com/PolymerElements/paper-input/issues/531)
![image](https://user-images.githubusercontent.com/1168053/52117275-9ce50680-2613-11e9-9c10-aeb81c99129a.png)

Thrown by `paper-textarea` with initial value and `auto-validate` like:
```html
<paper-textarea label="autoresizing textarea input" value="will throw" auto-validate></paper-textarea>
```

In this case, validation happens too early causing a read of `this.$.textarea.validity.valid`  to cause the error (`this.$` is undefined)
