### PR TITLE
Update autofocus property to be non-nullable

### DIFF
--- a/iron-autogrow-textarea.js
+++ b/iron-autogrow-textarea.js
@@ -149,6 +149,8 @@ Polymer({
 
     /**
      * Bound to the textarea's `autofocus` attribute.
+     *
+     * @type {boolean}
      */
     autofocus: {type: Boolean, value: false},
 

--- a/iron-autogrow-textarea.js
+++ b/iron-autogrow-textarea.js
@@ -150,7 +150,7 @@ Polymer({
     /**
      * Bound to the textarea's `autofocus` attribute.
      *
-     * @type {boolean}
+     * @type {!boolean}
      */
     autofocus: {type: Boolean, value: false},
 


### PR DESCRIPTION
In TypeScript 3.8 a new property `autofocus` was introduced on `HTMLElement`. When this component extends `HTMLElement` the `autofocus` properties now conflict. This change marks `autofocus` as non-nullable to align with TypeScript's `HTMLElement`.

Here's a playground link demoing the issue: http://www.typescriptlang.org/play/#code/JYOwLgpgTgZghgYwgAgCoQB5gIJQnAYQHsBbAByJAnGU0hABMBnZACVQFkAZAUQBsIJamGQBvAFDIpyOAFcwRGEQSymALmQAjIkQFwQyAD7IQsvnyPJZjCDFAQGAbnEBfcUA

To see past behavior set the version to 3.7.5, and the current by setting the version to 3.8.3.